### PR TITLE
fix: 日本語ラベル「問題提案」を「出題案」に統一

### DIFF
--- a/apps/api/src/domain/question-proposal/__tests__/question-proposal.test.ts
+++ b/apps/api/src/domain/question-proposal/__tests__/question-proposal.test.ts
@@ -66,7 +66,7 @@ describe("QuestionProposal", () => {
       const { proposal: approved } = proposal.approve();
 
       expect(() => approved.approve()).toThrow(
-        "問題提案を承認できるステータスではありません",
+        "出題案を承認できるステータスではありません",
       );
     });
 
@@ -77,7 +77,7 @@ describe("QuestionProposal", () => {
       );
 
       expect(() => rejected.approve()).toThrow(
-        "問題提案を承認できるステータスではありません",
+        "出題案を承認できるステータスではありません",
       );
     });
   });
@@ -104,7 +104,7 @@ describe("QuestionProposal", () => {
       const { proposal: approved } = proposal.approve();
 
       expect(() => approved.reject(RejectReason.create("理由"))).toThrow(
-        "問題提案を却下できるステータスではありません",
+        "出題案を却下できるステータスではありません",
       );
     });
 
@@ -115,7 +115,7 @@ describe("QuestionProposal", () => {
       );
 
       expect(() => rejected.reject(RejectReason.create("別の理由"))).toThrow(
-        "問題提案を却下できるステータスではありません",
+        "出題案を却下できるステータスではありません",
       );
     });
   });
@@ -152,7 +152,7 @@ describe("QuestionProposal", () => {
       const { proposal: approved } = proposal.approve();
 
       expect(() => approved.edit(buildEditParams())).toThrow(
-        "問題提案を編集できるステータスではありません",
+        "出題案を編集できるステータスではありません",
       );
     });
   });
@@ -203,7 +203,7 @@ describe("QuestionProposal", () => {
 
       // approved 状態なので approve するとエラー
       expect(() => restored.approve()).toThrow(
-        "問題提案を承認できるステータスではありません",
+        "出題案を承認できるステータスではありません",
       );
     });
 
@@ -226,7 +226,7 @@ describe("QuestionProposal", () => {
 
       // approved 状態なので edit するとエラー
       expect(() => restored.edit(buildEditParams())).toThrow(
-        "問題提案を編集できるステータスではありません",
+        "出題案を編集できるステータスではありません",
       );
     });
   });

--- a/apps/api/src/domain/question-proposal/question-proposal.ts
+++ b/apps/api/src/domain/question-proposal/question-proposal.ts
@@ -82,7 +82,7 @@ export class QuestionProposal {
   } {
     if (!this.canEdit()) {
       throw new Error(
-        `問題提案を編集できるステータスではありません。ステータス=${this.status}`,
+        `出題案を編集できるステータスではありません。ステータス=${this.status}`,
       );
     }
 
@@ -115,7 +115,7 @@ export class QuestionProposal {
   } {
     if (!this.canApprove()) {
       throw new Error(
-        `問題提案を承認できるステータスではありません。ステータス=${this.status}`,
+        `出題案を承認できるステータスではありません。ステータス=${this.status}`,
       );
     }
 
@@ -147,7 +147,7 @@ export class QuestionProposal {
   } {
     if (!this.canReject()) {
       throw new Error(
-        `問題提案を却下できるステータスではありません。ステータス=${this.status}`,
+        `出題案を却下できるステータスではありません。ステータス=${this.status}`,
       );
     }
 

--- a/apps/api/src/presentation/routes/question-proposal/question-proposal.route.ts
+++ b/apps/api/src/presentation/routes/question-proposal/question-proposal.route.ts
@@ -80,7 +80,7 @@ const listProposalRoute = createRoute({
   method: "get",
   path: "/list",
   tags: ["QuestionProposal"],
-  summary: "問題提案一覧を取得",
+  summary: "出題案一覧を取得",
   request: {
     query: z.object({
       status: z.enum(["pending", "approved", "rejected"]).optional(),
@@ -90,7 +90,7 @@ const listProposalRoute = createRoute({
   },
   responses: {
     200: {
-      description: "問題提案一覧",
+      description: "出題案一覧",
       content: {
         "application/json": {
           schema: z.object({
@@ -107,7 +107,7 @@ const getProposalRoute = createRoute({
   method: "get",
   path: "/:id",
   tags: ["QuestionProposal"],
-  summary: "問題提案詳細を取得",
+  summary: "出題案詳細を取得",
   request: {
     params: z.object({
       id: z.string().uuid(),
@@ -115,7 +115,7 @@ const getProposalRoute = createRoute({
   },
   responses: {
     200: {
-      description: "問題提案詳細",
+      description: "出題案詳細",
       content: {
         "application/json": { schema: questionProposalWithDatesSchema },
       },
@@ -133,7 +133,7 @@ const getProposalRoute = createRoute({
 
 const proposalResponse = {
   200: {
-    description: "問題提案",
+    description: "出題案",
     content: { "application/json": { schema: questionProposalSchema } },
   },
 } as const;
@@ -142,7 +142,7 @@ const createProposalRoute = createRoute({
   method: "post",
   path: "/create",
   tags: ["QuestionProposal"],
-  summary: "問題提案を作成",
+  summary: "出題案を作成",
   request: {
     body: { content: { "application/json": { schema: createSchema } } },
   },
@@ -153,7 +153,7 @@ const updateProposalRoute = createRoute({
   method: "post",
   path: "/update",
   tags: ["QuestionProposal"],
-  summary: "問題提案を更新",
+  summary: "出題案を更新",
   request: {
     body: { content: { "application/json": { schema: updateSchema } } },
   },
@@ -164,7 +164,7 @@ const approveProposalRoute = createRoute({
   method: "post",
   path: "/approve",
   tags: ["QuestionProposal"],
-  summary: "問題提案を承認",
+  summary: "出題案を承認",
   request: {
     body: { content: { "application/json": { schema: approveSchema } } },
   },
@@ -175,7 +175,7 @@ const rejectProposalRoute = createRoute({
   method: "post",
   path: "/reject",
   tags: ["QuestionProposal"],
-  summary: "問題提案を却下",
+  summary: "出題案を却下",
   request: {
     body: { content: { "application/json": { schema: rejectSchema } } },
   },
@@ -186,7 +186,7 @@ const generateFromUrlRoute = createRoute({
   method: "post",
   path: "/generate-from-url",
   tags: ["QuestionProposal"],
-  summary: "URLから問題提案を自動生成",
+  summary: "URLから出題案を自動生成",
   request: {
     body: {
       content: { "application/json": { schema: generateFromUrlSchema } },
@@ -194,7 +194,7 @@ const generateFromUrlRoute = createRoute({
   },
   responses: {
     200: {
-      description: "生成された問題提案一覧",
+      description: "生成された出題案一覧",
       content: {
         "application/json": { schema: z.array(questionProposalSchema) },
       },

--- a/apps/web/src/features/admin/admin-layout.tsx
+++ b/apps/web/src/features/admin/admin-layout.tsx
@@ -4,7 +4,7 @@ import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/auth-client";
 
 const navItems = [
-  { to: "/admin/proposals", label: "問題提案", icon: FileText },
+  { to: "/admin/proposals", label: "出題案", icon: FileText },
   { to: "/admin/categories", label: "カテゴリ", icon: FolderOpen },
 ];
 

--- a/apps/web/src/features/admin/proposals/proposal-list-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-list-page.tsx
@@ -53,7 +53,7 @@ export function ProposalListPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold tracking-tight">問題提案</h2>
+        <h2 className="text-2xl font-bold tracking-tight">出題案</h2>
         <div className="flex items-center gap-2">
           <Button onClick={() => navigate("/admin/proposals/new")}>
             <Plus className="size-4" />

--- a/apps/web/src/features/admin/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-new-page.tsx
@@ -156,7 +156,7 @@ export function ProposalNewPage() {
         </Button>
       </div>
 
-      <h2 className="text-2xl font-bold tracking-tight">問題提案を作成</h2>
+      <h2 className="text-2xl font-bold tracking-tight">出題案を作成</h2>
 
       <Form {...form}>
         <form


### PR DESCRIPTION
## Summary
- ドメイン層エラーメッセージ、OpenAPI ドキュメント、テスト期待値、フロントエンド UI の「問題提案」を「出題案」に一括置換
- 英語名 `QuestionProposal` は変更なし
- 全6ファイル・計24箇所を修正

Closes #5

## Test plan
- [x] `pnpm --filter api test` 全68件パス
- [x] `pnpm lint` エラーなし
- [x] プロジェクト全体で「問題提案」がゼロであることを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)