### PR TITLE
feat: カテゴリの更新・削除 API を追加

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,7 +3,7 @@ import { logger } from "hono/logger";
 import { createApiRoutes } from "./presentation/routes/index.js";
 import { dependencies } from "./composition-root";
 import { consoleLogger } from "./lib/logger";
-import { DomainConflictError } from "./domain/errors.js";
+import { ConflictError, EntityNotFoundError } from "./domain/errors.js";
 import { Scalar } from "@scalar/hono-api-reference";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { auth } from "./infrastructure/auth/auth.js";
@@ -27,9 +27,6 @@ app.use(
 );
 
 // --------------- Auth routes (Better Auth) ---------------
-// app.on(["POST", "GET"]) から app.use() に変更した理由:
-// 1. requireAuth より先に実行させ、認証エンドポイント自体が保護されないようにする
-// 2. Better Auth が内部で全 HTTP メソッドをハンドルするため、メソッド制限は不要
 app.use("/api/auth/*", async (c) => {
   return auth.handler(c.req.raw);
 });
@@ -37,7 +34,10 @@ app.use("/api/auth/*", async (c) => {
 app.use(logger());
 
 app.onError((err, c) => {
-  if (err instanceof DomainConflictError) {
+  if (err instanceof EntityNotFoundError) {
+    return c.json({ error: err.message }, 404);
+  }
+  if (err instanceof ConflictError) {
     return c.json({ error: err.message }, 409);
   }
   consoleLogger.error("Unexpected error", { error: err, path: c.req.path });

--- a/apps/api/src/application/category/delete-category-use-case.ts
+++ b/apps/api/src/application/category/delete-category-use-case.ts
@@ -1,0 +1,27 @@
+import { Id } from "../../domain/id.js";
+import { EntityNotFoundError } from "../../domain/errors.js";
+import type { CategoryDeletionPolicy } from "../../domain/category/category-deletion-policy.js";
+import type { CategoryRepository } from "../../domain/category/category-repository.js";
+import type { Category } from "../../domain/category/category.js";
+import type { UnitOfWork } from "../unit-of-work.js";
+
+export class DeleteCategoryUseCase {
+  constructor(
+    private uow: UnitOfWork,
+    private categoryRepository: CategoryRepository,
+    private deletionPolicy: CategoryDeletionPolicy,
+  ) {}
+
+  async execute(id: string): Promise<void> {
+    return this.uow.run(async () => {
+      const categoryId = Id.of<Category>(id);
+      const category = await this.categoryRepository.findById(categoryId);
+      if (!category) {
+        throw new EntityNotFoundError("カテゴリが見つかりません");
+      }
+
+      await this.deletionPolicy.ensureDeletable(categoryId);
+      await this.categoryRepository.delete(categoryId);
+    });
+  }
+}

--- a/apps/api/src/application/category/update-category-use-case.ts
+++ b/apps/api/src/application/category/update-category-use-case.ts
@@ -1,0 +1,40 @@
+import { Id } from "../../domain/id.js";
+import { CategoryName } from "../../domain/category/category-name.js";
+import { EntityNotFoundError } from "../../domain/errors.js";
+import type { CategoryNameDuplicateChecker } from "../../domain/category/category-name-duplicate-checker.js";
+import type { CategoryRepository } from "../../domain/category/category-repository.js";
+import type { Category } from "../../domain/category/category.js";
+import type { UnitOfWork } from "../unit-of-work.js";
+
+export type UpdateCategoryInput = {
+  id: string;
+  name: string;
+};
+
+export class UpdateCategoryUseCase {
+  constructor(
+    private uow: UnitOfWork,
+    private categoryRepository: CategoryRepository,
+    private duplicateChecker: CategoryNameDuplicateChecker,
+  ) {}
+
+  async execute(input: UpdateCategoryInput): Promise<Category> {
+    return this.uow.run(async () => {
+      const categoryId = Id.of<Category>(input.id);
+      const category = await this.categoryRepository.findById(categoryId);
+      if (!category) {
+        throw new EntityNotFoundError("カテゴリが見つかりません");
+      }
+
+      const newName = CategoryName.create(input.name);
+
+      if (!category.name.equals(newName)) {
+        await this.duplicateChecker.ensure(newName);
+      }
+
+      const updated = category.changeName(newName);
+      await this.categoryRepository.save(updated);
+      return updated;
+    });
+  }
+}

--- a/apps/api/src/composition-root.ts
+++ b/apps/api/src/composition-root.ts
@@ -9,6 +9,8 @@ import { GetRandomQuestionsUseCase } from "./application/question/get-random-que
 import { CreateQuestionUseCase } from "./application/question/create-question-use-case.js";
 import { ListCategoriesUseCase } from "./application/category/list-categories-use-case.js";
 import { CreateCategoryUseCase } from "./application/category/create-category-use-case.js";
+import { UpdateCategoryUseCase } from "./application/category/update-category-use-case.js";
+import { DeleteCategoryUseCase } from "./application/category/delete-category-use-case.js";
 import { CreateQuestionProposalUseCase } from "./application/question-proposal/create-question-proposal-use-case.js";
 import { UpdateQuestionProposalUseCase } from "./application/question-proposal/update-question-proposal-use-case.js";
 import { ApproveQuestionProposalUseCase } from "./application/question-proposal/approve-question-proposal-use-case.js";
@@ -21,6 +23,7 @@ import { DrizzleQuestionProposalListQueryService } from "./infrastructure/questi
 import { DrizzleUserQueryService } from "./infrastructure/user/drizzle-user-query-service.js";
 import { CheckUsernameAvailabilityUseCase } from "./application/user/check-username-availability-use-case.js";
 import { CategoryNameDuplicateChecker } from "./domain/category/category-name-duplicate-checker.js";
+import { CategoryDeletionPolicy } from "./domain/category/category-deletion-policy.js";
 import { requireEnv } from "./env.js";
 
 // UnitOfWork
@@ -40,6 +43,7 @@ const userQueryService = new DrizzleUserQueryService();
 const categoryNameDuplicateChecker = new CategoryNameDuplicateChecker(
   categoryQueryService,
 );
+const categoryDeletionPolicy = new CategoryDeletionPolicy(categoryQueryService);
 
 // 外部サービスアダプター（API キーは初回呼び出し時に遅延取得）
 const questionGenerationAdapter = new GeminiQuestionGenerationAdapter(() =>
@@ -80,6 +84,16 @@ const createCategory = new CreateCategoryUseCase(
   categoryRepository,
   categoryNameDuplicateChecker,
 );
+const updateCategory = new UpdateCategoryUseCase(
+  unitOfWork,
+  categoryRepository,
+  categoryNameDuplicateChecker,
+);
+const deleteCategory = new DeleteCategoryUseCase(
+  unitOfWork,
+  categoryRepository,
+  categoryDeletionPolicy,
+);
 const generateQuestionProposals = new GenerateQuestionProposalsUseCase(
   unitOfWork,
   questionGenerationAdapter,
@@ -112,6 +126,8 @@ export const dependencies = {
   getQuestionProposal,
   listCategories,
   createCategory,
+  updateCategory,
+  deleteCategory,
   generateQuestionProposals,
 };
 

--- a/apps/api/src/domain/category/category-deletion-policy.ts
+++ b/apps/api/src/domain/category/category-deletion-policy.ts
@@ -1,0 +1,16 @@
+import { ConflictError } from "../errors.js";
+import type { CategoryId } from "./category-id.js";
+import type { CategoryQueryService } from "./category-query-service.js";
+
+export class CategoryDeletionPolicy {
+  constructor(private queryService: CategoryQueryService) {}
+
+  async ensureDeletable(id: CategoryId): Promise<void> {
+    const hasRelated = await this.queryService.hasRelatedData(id);
+    if (hasRelated) {
+      throw new ConflictError(
+        "関連する問題または出題案が存在するため、カテゴリを削除できません",
+      );
+    }
+  }
+}

--- a/apps/api/src/domain/category/category-name-duplicate-checker.ts
+++ b/apps/api/src/domain/category/category-name-duplicate-checker.ts
@@ -1,4 +1,4 @@
-import { DomainConflictError } from "../errors.js";
+import { ConflictError } from "../errors.js";
 import type { CategoryName } from "./category-name.js";
 import type { CategoryQueryService } from "./category-query-service.js";
 
@@ -8,7 +8,7 @@ export class CategoryNameDuplicateChecker {
   async ensure(name: CategoryName): Promise<void> {
     const exists = await this.queryService.existsByName(name);
     if (exists) {
-      throw new DomainConflictError(
+      throw new ConflictError(
         `カテゴリ名「${name.value}」は既に使用されています`,
       );
     }

--- a/apps/api/src/domain/category/category-query-service.ts
+++ b/apps/api/src/domain/category/category-query-service.ts
@@ -1,3 +1,4 @@
+import type { CategoryId } from "./category-id.js";
 import type { CategoryName } from "./category-name.js";
 
 export type CategoryDto = {
@@ -8,4 +9,5 @@ export type CategoryDto = {
 export interface CategoryQueryService {
   findAll(): Promise<CategoryDto[]>;
   existsByName(name: CategoryName): Promise<boolean>;
+  hasRelatedData(id: CategoryId): Promise<boolean>;
 }

--- a/apps/api/src/domain/category/category-repository.ts
+++ b/apps/api/src/domain/category/category-repository.ts
@@ -1,5 +1,8 @@
 import type { Category } from "./category.js";
+import type { CategoryId } from "./category-id.js";
 
 export interface CategoryRepository {
   save(category: Category): Promise<void>;
+  findById(id: CategoryId): Promise<Category | null>;
+  delete(id: CategoryId): Promise<void>;
 }

--- a/apps/api/src/domain/category/category.ts
+++ b/apps/api/src/domain/category/category.ts
@@ -11,6 +11,10 @@ export class Category {
     return new Category(params.id, params.name);
   }
 
+  changeName(newName: CategoryName): Category {
+    return new Category(this.id, newName);
+  }
+
   equals(other: Category): boolean {
     return this.id === other.id;
   }

--- a/apps/api/src/domain/errors.ts
+++ b/apps/api/src/domain/errors.ts
@@ -1,6 +1,13 @@
-export class DomainConflictError extends Error {
+export class ConflictError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "DomainConflictError";
+    this.name = "ConflictError";
+  }
+}
+
+export class EntityNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EntityNotFoundError";
   }
 }

--- a/apps/api/src/infrastructure/category/drizzle-category-query-service.ts
+++ b/apps/api/src/infrastructure/category/drizzle-category-query-service.ts
@@ -1,10 +1,15 @@
 import { eq } from "drizzle-orm";
-import { categories } from "../db/schema.js";
+import {
+  categories,
+  questions,
+  questionProposalProjections,
+} from "../db/schema.js";
 import { getCurrentTransaction } from "../db/transaction-context.js";
 import type {
   CategoryQueryService,
   CategoryDto,
 } from "../../domain/category/category-query-service.js";
+import type { CategoryId } from "../../domain/category/category-id.js";
 import type { CategoryName } from "../../domain/category/category-name.js";
 
 export class DrizzleCategoryQueryService implements CategoryQueryService {
@@ -28,5 +33,25 @@ export class DrizzleCategoryQueryService implements CategoryQueryService {
       .where(eq(categories.name, name.value))
       .limit(1);
     return rows.length > 0;
+  }
+
+  async hasRelatedData(id: CategoryId): Promise<boolean> {
+    const tx = getCurrentTransaction();
+
+    const questionRows = await tx
+      .select({ id: questions.id })
+      .from(questions)
+      .where(eq(questions.categoryId, id))
+      .limit(1);
+    if (questionRows.length > 0) return true;
+
+    const proposalRows = await tx
+      .select({
+        questionProposalId: questionProposalProjections.questionProposalId,
+      })
+      .from(questionProposalProjections)
+      .where(eq(questionProposalProjections.categoryId, id))
+      .limit(1);
+    return proposalRows.length > 0;
   }
 }

--- a/apps/api/src/infrastructure/category/drizzle-category-repository.ts
+++ b/apps/api/src/infrastructure/category/drizzle-category-repository.ts
@@ -1,14 +1,46 @@
+import { eq } from "drizzle-orm";
 import { categories } from "../db/schema.js";
 import { getCurrentTransaction } from "../db/transaction-context.js";
 import type { CategoryRepository } from "../../domain/category/category-repository.js";
-import type { Category } from "../../domain/category/category.js";
+import type { CategoryId } from "../../domain/category/category-id.js";
+import { Category } from "../../domain/category/category.js";
+import { CategoryName } from "../../domain/category/category-name.js";
+import { Id } from "../../domain/id.js";
 
 export class DrizzleCategoryRepository implements CategoryRepository {
   async save(category: Category): Promise<void> {
     const tx = getCurrentTransaction();
-    await tx.insert(categories).values({
-      id: category.id,
-      name: category.name.value,
+    await tx
+      .insert(categories)
+      .values({
+        id: category.id,
+        name: category.name.value,
+      })
+      .onConflictDoUpdate({
+        target: categories.id,
+        set: { name: category.name.value },
+      });
+  }
+
+  async findById(id: CategoryId): Promise<Category | null> {
+    const tx = getCurrentTransaction();
+    const rows = await tx
+      .select({ id: categories.id, name: categories.name })
+      .from(categories)
+      .where(eq(categories.id, id))
+      .limit(1);
+
+    if (rows.length === 0) return null;
+
+    const row = rows[0];
+    return Category.create({
+      id: Id.of<Category>(row.id),
+      name: CategoryName.create(row.name),
     });
+  }
+
+  async delete(id: CategoryId): Promise<void> {
+    const tx = getCurrentTransaction();
+    await tx.delete(categories).where(eq(categories.id, id));
   }
 }

--- a/apps/api/src/presentation/routes/category/category.route.ts
+++ b/apps/api/src/presentation/routes/category/category.route.ts
@@ -8,9 +8,11 @@ const categorySchema = z
   })
   .openapi("Category");
 
+const errorSchema = z.object({ error: z.string() });
+
 const listRoute = createRoute({
   method: "get",
-  path: "/list",
+  path: "/",
   tags: ["Category"],
   summary: "カテゴリ一覧を取得",
   responses: {
@@ -36,7 +38,7 @@ const createCategoryResponseSchema = z
 
 const createRoute_ = createRoute({
   method: "post",
-  path: "/create",
+  path: "/",
   tags: ["Category"],
   summary: "カテゴリを作成",
   request: {
@@ -45,7 +47,7 @@ const createRoute_ = createRoute({
     },
   },
   responses: {
-    200: {
+    201: {
       description: "作成されたカテゴリ",
       content: {
         "application/json": { schema: createCategoryResponseSchema },
@@ -54,10 +56,68 @@ const createRoute_ = createRoute({
     409: {
       description: "カテゴリ名が重複",
       content: {
-        "application/json": {
-          schema: z.object({ error: z.string() }),
-        },
+        "application/json": { schema: errorSchema },
       },
+    },
+  },
+});
+
+const categoryIdParam = z.object({
+  id: z.string().uuid(),
+});
+
+const updateCategorySchema = z
+  .object({
+    name: z.string(),
+  })
+  .openapi("UpdateCategoryRequest");
+
+const updateRoute = createRoute({
+  method: "put",
+  path: "/:id",
+  tags: ["Category"],
+  summary: "カテゴリを更新",
+  request: {
+    params: categoryIdParam,
+    body: {
+      content: { "application/json": { schema: updateCategorySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "更新されたカテゴリ",
+      content: { "application/json": { schema: categorySchema } },
+    },
+    404: {
+      description: "カテゴリが見つからない",
+      content: { "application/json": { schema: errorSchema } },
+    },
+    409: {
+      description: "カテゴリ名が重複",
+      content: { "application/json": { schema: errorSchema } },
+    },
+  },
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/:id",
+  tags: ["Category"],
+  summary: "カテゴリを削除",
+  request: {
+    params: categoryIdParam,
+  },
+  responses: {
+    204: {
+      description: "削除成功",
+    },
+    404: {
+      description: "カテゴリが見つからない",
+      content: { "application/json": { schema: errorSchema } },
+    },
+    409: {
+      description: "関連データが存在するため削除不可",
+      content: { "application/json": { schema: errorSchema } },
     },
   },
 });
@@ -73,6 +133,23 @@ export const createCategoryRoute = (deps: Dependencies) =>
       const category = await deps.createCategory.execute(input);
       return c.json(
         { id: category.id as string, name: category.name.value },
+        201,
+      );
+    })
+    .openapi(updateRoute, async (c) => {
+      const { id } = c.req.valid("param");
+      const input = c.req.valid("json");
+      const category = await deps.updateCategory.execute({
+        id,
+        name: input.name,
+      });
+      return c.json(
+        { id: category.id as string, name: category.name.value },
         200,
       );
+    })
+    .openapi(deleteRoute, async (c) => {
+      const { id } = c.req.valid("param");
+      await deps.deleteCategory.execute(id);
+      return c.body(null, 204);
     });

--- a/apps/api/src/presentation/routes/index.ts
+++ b/apps/api/src/presentation/routes/index.ts
@@ -35,7 +35,10 @@ export const createApiRoutes = (deps: Dependencies) =>
     .route("/random-question", createRandomQuestionRoute(deps))
     .route("/user", createUserRoute(deps))
     .use("/*", requireAuth)
-    .use("/category/create", requireAdmin)
+    .use("/category/*", async (c, next) => {
+      if (c.req.method === "GET") return next();
+      return requireAdmin(c, next);
+    })
     .use("/question/create", requireAdmin)
     .use("/question-proposal/*", requireAdmin)
     .route("/category", createCategoryRoute(deps))

--- a/apps/web/src/features/admin/categories/category-list-page.tsx
+++ b/apps/web/src/features/admin/categories/category-list-page.tsx
@@ -55,7 +55,7 @@ export function CategoryListPage() {
   const { data: categories, isLoading } = useQuery({
     queryKey: ["categories"],
     queryFn: async () => {
-      const res = await client.api.category.list.$get();
+      const res = await client.api.category.$get();
       if (!res.ok) throw new Error("Failed to fetch categories");
       return res.json();
     },
@@ -63,7 +63,7 @@ export function CategoryListPage() {
 
   const createMutation = useMutation({
     mutationFn: async (name: string) => {
-      const res = await client.api.category.create.$post({
+      const res = await client.api.category.$post({
         json: { name },
       });
       if (!res.ok) {

--- a/apps/web/src/features/admin/proposals/proposal-edit-form.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-edit-form.tsx
@@ -97,7 +97,7 @@ export function ProposalEditForm({
   const { data: categories } = useQuery({
     queryKey: ["categories"],
     queryFn: async () => {
-      const res = await client.api.category.list.$get();
+      const res = await client.api.category.$get();
       if (!res.ok) throw new Error("Failed to fetch categories");
       return res.json();
     },

--- a/apps/web/src/features/admin/proposals/proposal-generate-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-generate-page.tsx
@@ -52,7 +52,7 @@ export function ProposalGeneratePage() {
   const { data: categories } = useQuery({
     queryKey: ["categories"],
     queryFn: async () => {
-      const res = await client.api.category.list.$get();
+      const res = await client.api.category.$get();
       if (!res.ok) throw new Error("Failed to fetch categories");
       return res.json();
     },

--- a/apps/web/src/features/admin/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-new-page.tsx
@@ -93,7 +93,7 @@ export function ProposalNewPage() {
   const { data: categories } = useQuery({
     queryKey: ["categories"],
     queryFn: async () => {
-      const res = await client.api.category.list.$get();
+      const res = await client.api.category.$get();
       if (!res.ok) throw new Error("Failed to fetch categories");
       return res.json();
     },


### PR DESCRIPTION
## Summary

- `PUT /api/category/:id`（更新）と `DELETE /api/category/:id`（削除）API を追加
- 既存の `/category/list`, `/category/create` を RESTful な URL（`GET /category`, `POST /category`）に修正
- `EntityNotFoundError` / `ConflictError` を導入し、グローバルエラーハンドラで 404/409 に変換
- `CategoryDeletionPolicy` ドメインサービスで関連データ（questions, questionProposalProjections）の存在チェックを実施
- `CategoryRepository.save` を upsert に統合し、`update` メソッドを廃止
- POST レスポンスを `201 Created`、DELETE を `204 No Content` に変更

## Test plan

- [ ] `pnpm build` が成功すること
- [ ] `pnpm lint` がエラーなしで通ること
- [ ] Scalar UI で PUT /api/category/:id が正常に動作すること
- [ ] Scalar UI で DELETE /api/category/:id が正常に動作すること
- [ ] 存在しないカテゴリへの PUT/DELETE が 404 を返すこと
- [ ] 関連データがあるカテゴリの DELETE が 409 を返すこと
- [ ] 重複する名前への PUT が 409 を返すこと
- [ ] フロントのカテゴリ一覧・作成が引き続き動作すること

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)