### PR TITLE
feat: カテゴリ一覧に問題数と出題案数を表示

### DIFF
--- a/apps/api/src/domain/category/query-service/category-query-service.ts
+++ b/apps/api/src/domain/category/query-service/category-query-service.ts
@@ -5,6 +5,7 @@ export type CategoryDto = {
   id: string;
   name: string;
   questionCount: number;
+  proposalCount: number;
 };
 
 export interface CategoryQueryService {

--- a/apps/api/src/infrastructure/category/drizzle-category-query-service.ts
+++ b/apps/api/src/infrastructure/category/drizzle-category-query-service.ts
@@ -1,4 +1,4 @@
-import { eq, count } from "drizzle-orm";
+import { eq, count, sql } from "drizzle-orm";
 import {
   categories,
   questions,
@@ -15,20 +15,43 @@ import type { CategoryName } from "../../domain/category/value-object/category-n
 export class DrizzleCategoryQueryService implements CategoryQueryService {
   async findAll(): Promise<CategoryDto[]> {
     const tx = getCurrentTransaction();
+
+    const qCount = tx
+      .select({
+        categoryId: questions.categoryId,
+        cnt: count(questions.id).as("question_cnt"),
+      })
+      .from(questions)
+      .groupBy(questions.categoryId)
+      .as("q_count");
+
+    const pCount = tx
+      .select({
+        categoryId: questionProposalProjections.categoryId,
+        cnt: count(questionProposalProjections.questionProposalId).as(
+          "proposal_cnt",
+        ),
+      })
+      .from(questionProposalProjections)
+      .groupBy(questionProposalProjections.categoryId)
+      .as("p_count");
+
     const rows = await tx
       .select({
         id: categories.id,
         name: categories.name,
-        questionCount: count(questions.id),
+        questionCount: sql<number>`coalesce(${qCount.cnt}, 0)`,
+        proposalCount: sql<number>`coalesce(${pCount.cnt}, 0)`,
       })
       .from(categories)
-      .leftJoin(questions, eq(categories.id, questions.categoryId))
-      .groupBy(categories.id, categories.name);
+      .leftJoin(qCount, eq(categories.id, qCount.categoryId))
+      .leftJoin(pCount, eq(categories.id, pCount.categoryId));
 
     return rows.map((row) => ({
       id: row.id,
       name: row.name,
       questionCount: Number(row.questionCount),
+      proposalCount: Number(row.proposalCount),
     }));
   }
 

--- a/apps/api/src/presentation/routes/categories/categories.route.ts
+++ b/apps/api/src/presentation/routes/categories/categories.route.ts
@@ -15,6 +15,7 @@ const categoryWithCountSchema = z
     id: z.string().uuid(),
     name: z.string(),
     questionCount: z.number().int(),
+    proposalCount: z.number().int(),
   })
   .openapi("CategoryWithCount");
 

--- a/apps/web/src/features/admin/categories/category-list-page.tsx
+++ b/apps/web/src/features/admin/categories/category-list-page.tsx
@@ -59,7 +59,12 @@ const categoryFormSchema = z.object({
 
 type CategoryForm = z.infer<typeof categoryFormSchema>;
 
-type Category = { id: string; name: string };
+type Category = {
+  id: string;
+  name: string;
+  questionCount: number;
+  proposalCount: number;
+};
 
 export function CategoryListPage() {
   const queryClient = useQueryClient();
@@ -212,6 +217,12 @@ export function CategoryListPage() {
             <TableHeader className="bg-primary/10">
               <TableRow className="border-b-2 border-primary/30">
                 <TableHead className="font-bold text-primary">名前</TableHead>
+                <TableHead className="w-24 text-right font-bold text-primary">
+                  問題数
+                </TableHead>
+                <TableHead className="w-24 text-right font-bold text-primary">
+                  出題案
+                </TableHead>
                 <TableHead className="w-12" />
               </TableRow>
             </TableHeader>
@@ -219,7 +230,7 @@ export function CategoryListPage() {
               {categories?.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={2}
+                    colSpan={4}
                     className="text-center text-muted-foreground"
                   >
                     カテゴリがありません
@@ -229,6 +240,12 @@ export function CategoryListPage() {
                 categories?.map((cat) => (
                   <TableRow key={cat.id}>
                     <TableCell className="font-medium">{cat.name}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {cat.questionCount}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {cat.proposalCount}
+                    </TableCell>
                     <TableCell>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

- カテゴリ一覧 API に `proposalCount`（出題案数）を追加
- クエリをサブクエリ方式に変更し、複数 LEFT JOIN によるカウント重複を防止
- 管理画面のカテゴリ一覧テーブルに「問題数」「出題案」列を表示

Closes #31

## Test plan

- [ ] `pnpm dev` でローカルサーバーを起動し、管理画面のカテゴリ一覧にアクセス
- [ ] 各カテゴリに問題数と出題案数が正しく表示されることを確認
- [ ] 問題・出題案が0件のカテゴリで `0` が表示されることを確認
- [ ] `pnpm lint` でリントエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)