### PR TITLE
feat: 成績ダッシュボード機能の実装

### DIFF
--- a/apps/api/src/application/drill-session/get-category-scores.ts
+++ b/apps/api/src/application/drill-session/get-category-scores.ts
@@ -1,0 +1,56 @@
+import type {
+  DrillStatsQueryService,
+  CategoryScoreDto,
+  LatestAnswerRow,
+} from "../../domain/drill-session/query-service/drill-stats-query-service.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+export class GetCategoryScores {
+  constructor(
+    private uow: UnitOfWork,
+    private queryService: DrillStatsQueryService,
+  ) {}
+
+  async execute(userId: string): Promise<CategoryScoreDto[]> {
+    return this.uow.run(async () => {
+      const [latestAnswers, questionCounts] = await Promise.all([
+        this.queryService.getLatestAnswers(userId),
+        this.queryService.getQuestionCounts(),
+      ]);
+
+      const countMap = new Map(
+        questionCounts.map((r) => [r.categoryId, r.total]),
+      );
+
+      const categoryMap = new Map<
+        string,
+        { categoryName: string; answers: LatestAnswerRow[] }
+      >();
+      for (const a of latestAnswers) {
+        const existing = categoryMap.get(a.categoryId);
+        if (existing) {
+          existing.answers.push(a);
+        } else {
+          categoryMap.set(a.categoryId, {
+            categoryName: a.categoryName,
+            answers: [a],
+          });
+        }
+      }
+
+      return Array.from(categoryMap.entries()).map(
+        ([categoryId, { categoryName, answers }]) => {
+          const totalQuestions = countMap.get(categoryId) ?? 0;
+          const correctCount = answers.filter((a) => a.isCorrect).length;
+          return {
+            categoryId,
+            categoryName,
+            correctRate: answers.length > 0 ? correctCount / answers.length : 0,
+            coverageRate:
+              totalQuestions > 0 ? answers.length / totalQuestions : 0,
+          };
+        },
+      );
+    });
+  }
+}

--- a/apps/api/src/application/drill-session/get-drill-stats.ts
+++ b/apps/api/src/application/drill-session/get-drill-stats.ts
@@ -1,0 +1,93 @@
+import type {
+  DrillStatsQueryService,
+  OverallStatsDto,
+  StatsDto,
+  LatestAnswerRow,
+  CategoryQuestionCountRow,
+} from "../../domain/drill-session/query-service/drill-stats-query-service.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+export class GetDrillStats {
+  constructor(
+    private uow: UnitOfWork,
+    private queryService: DrillStatsQueryService,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    categoryId?: string;
+  }): Promise<OverallStatsDto | StatsDto | null> {
+    return this.uow.run(async () => {
+      const [latestAnswers, questionCounts] = await Promise.all([
+        this.queryService.getLatestAnswers(params.userId, params.categoryId),
+        this.queryService.getQuestionCounts(params.categoryId),
+      ]);
+
+      if (params.categoryId) {
+        return this.buildCategoryStats(latestAnswers, questionCounts);
+      }
+      return this.buildOverallStats(latestAnswers, questionCounts);
+    });
+  }
+
+  private buildCategoryStats(
+    latestAnswers: LatestAnswerRow[],
+    questionCounts: CategoryQuestionCountRow[],
+  ): StatsDto | null {
+    if (latestAnswers.length === 0) return null;
+
+    const totalQuestions = questionCounts[0]?.total ?? 0;
+    const correctCount = latestAnswers.filter((a) => a.isCorrect).length;
+
+    return {
+      totalAnswered: latestAnswers.length,
+      correctCount,
+      uniqueQuestionsAnswered: latestAnswers.length,
+      totalQuestions,
+    };
+  }
+
+  private buildOverallStats(
+    latestAnswers: LatestAnswerRow[],
+    questionCounts: CategoryQuestionCountRow[],
+  ): OverallStatsDto {
+    const countMap = new Map(
+      questionCounts.map((r) => [r.categoryId, r.total]),
+    );
+    const totalQuestions = questionCounts.reduce((sum, r) => sum + r.total, 0);
+    const correctCount = latestAnswers.filter((a) => a.isCorrect).length;
+
+    const categoryMap = new Map<
+      string,
+      { categoryName: string; answers: LatestAnswerRow[] }
+    >();
+    for (const a of latestAnswers) {
+      const existing = categoryMap.get(a.categoryId);
+      if (existing) {
+        existing.answers.push(a);
+      } else {
+        categoryMap.set(a.categoryId, {
+          categoryName: a.categoryName,
+          answers: [a],
+        });
+      }
+    }
+
+    return {
+      totalAnswered: latestAnswers.length,
+      correctCount,
+      uniqueQuestionsAnswered: latestAnswers.length,
+      totalQuestions,
+      categoryStats: Array.from(categoryMap.entries()).map(
+        ([categoryId, { categoryName, answers }]) => ({
+          categoryId,
+          categoryName,
+          totalAnswered: answers.length,
+          correctCount: answers.filter((a) => a.isCorrect).length,
+          uniqueQuestionsAnswered: answers.length,
+          totalQuestions: countMap.get(categoryId) ?? 0,
+        }),
+      ),
+    };
+  }
+}

--- a/apps/api/src/application/drill-session/get-recent-sessions.ts
+++ b/apps/api/src/application/drill-session/get-recent-sessions.ts
@@ -1,0 +1,33 @@
+import type {
+  DrillStatsQueryService,
+  SessionSummaryDto,
+} from "../../domain/drill-session/query-service/drill-stats-query-service.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+const MAX_LIMIT = 50;
+
+export class GetRecentSessions {
+  constructor(
+    private uow: UnitOfWork,
+    private drillStatsQueryService: DrillStatsQueryService,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    limit?: number;
+    offset?: number;
+    categoryId?: string;
+  }): Promise<SessionSummaryDto[]> {
+    const limit = Math.min(params.limit ?? 10, MAX_LIMIT);
+    const offset = params.offset ?? 0;
+
+    return this.uow.run(async () => {
+      return this.drillStatsQueryService.getRecentSessions(
+        params.userId,
+        limit,
+        offset,
+        params.categoryId,
+      );
+    });
+  }
+}

--- a/apps/api/src/application/drill-session/save-drill-session.ts
+++ b/apps/api/src/application/drill-session/save-drill-session.ts
@@ -1,0 +1,36 @@
+import { Id } from "../../domain/shared/id.ts";
+import {
+  DrillSession,
+  type DrillAnswer,
+  type DrillSessionId,
+} from "../../domain/drill-session/entity/drill-session.ts";
+import type { DrillSessionRepository } from "../../domain/drill-session/repository/drill-session-repository.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+export class SaveDrillSession {
+  constructor(
+    private uow: UnitOfWork,
+    private drillSessionRepository: DrillSessionRepository,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    categoryId: string | null;
+    answers: DrillAnswer[];
+    startedAt: string;
+  }): Promise<{ sessionId: string }> {
+    return this.uow.run(async () => {
+      const sessionId = Id.random<DrillSession>() as DrillSessionId;
+      const session = DrillSession.create({
+        id: sessionId,
+        userId: params.userId,
+        categoryId: params.categoryId,
+        answers: params.answers,
+        startedAt: new Date(params.startedAt),
+        completedAt: new Date(),
+      });
+      await this.drillSessionRepository.save(session);
+      return { sessionId: session.id };
+    });
+  }
+}

--- a/apps/api/src/composition-root.ts
+++ b/apps/api/src/composition-root.ts
@@ -29,6 +29,12 @@ import { CategoryNameDuplicateChecker } from "./domain/category/service/category
 import { CategoryDeletionPolicy } from "./domain/category/service/category-deletion-policy.ts";
 import { OnQuestionProposalApproved } from "./application/question-proposal/on-question-proposal-approved.ts";
 import { InMemoryEventPublisher } from "./infrastructure/event/in-memory-event-publisher.ts";
+import { DrizzleDrillSessionRepository } from "./infrastructure/drill-session/drizzle-drill-session-repository.ts";
+import { DrizzleDrillStatsQueryService } from "./infrastructure/drill-session/drizzle-drill-stats-query-service.ts";
+import { SaveDrillSession } from "./application/drill-session/save-drill-session.ts";
+import { GetDrillStats } from "./application/drill-session/get-drill-stats.ts";
+import { GetRecentSessions } from "./application/drill-session/get-recent-sessions.ts";
+import { GetCategoryScores } from "./application/drill-session/get-category-scores.ts";
 import { consoleLogger } from "./lib/logger.ts";
 import { requireEnv } from "./env.ts";
 
@@ -44,6 +50,8 @@ const questionProposalRepository = new DrizzleQuestionProposalRepository();
 const questionProposalProjectionQueryService =
   new DrizzleQuestionProposalProjectionQueryService();
 const userQueryService = new DrizzleUserQueryService();
+const drillSessionRepository = new DrizzleDrillSessionRepository();
+const drillStatsQueryService = new DrizzleDrillStatsQueryService();
 // イベントパブリッシャー & ハンドラ
 const eventPublisher = new InMemoryEventPublisher(consoleLogger);
 const onQuestionProposalApproved = new OnQuestionProposalApproved(
@@ -130,6 +138,20 @@ const checkUsernameAvailability = new CheckUsernameAvailability(
   userQueryService,
 );
 
+const saveDrillSession = new SaveDrillSession(
+  unitOfWork,
+  drillSessionRepository,
+);
+const getDrillStats = new GetDrillStats(unitOfWork, drillStatsQueryService);
+const getRecentSessions = new GetRecentSessions(
+  unitOfWork,
+  drillStatsQueryService,
+);
+const getCategoryScores = new GetCategoryScores(
+  unitOfWork,
+  drillStatsQueryService,
+);
+
 export const dependencies = {
   checkUsernameAvailability,
   getRandomQuestions,
@@ -148,6 +170,10 @@ export const dependencies = {
   updateCategory,
   deleteCategory,
   generateQuestionProposals,
+  saveDrillSession,
+  getDrillStats,
+  getRecentSessions,
+  getCategoryScores,
 };
 
 export type Dependencies = typeof dependencies;

--- a/apps/api/src/domain/drill-session/entity/drill-session.ts
+++ b/apps/api/src/domain/drill-session/entity/drill-session.ts
@@ -1,0 +1,49 @@
+import type { Id } from "../../shared/id.ts";
+
+export type DrillSessionId = Id<DrillSession>;
+
+export type DrillAnswer = {
+  questionId: string;
+  selectedIndexes: number[];
+  isCorrect: boolean;
+};
+
+export class DrillSession {
+  private constructor(
+    readonly id: DrillSessionId,
+    readonly userId: string,
+    readonly categoryId: string | null,
+    readonly answers: readonly DrillAnswer[],
+    readonly startedAt: Date,
+    readonly completedAt: Date,
+  ) {}
+
+  static create(params: {
+    id: DrillSessionId;
+    userId: string;
+    categoryId: string | null;
+    answers: DrillAnswer[];
+    startedAt: Date;
+    completedAt: Date;
+  }): DrillSession {
+    if (params.answers.length === 0) {
+      throw new Error("回答が1件以上必要です");
+    }
+    return new DrillSession(
+      params.id,
+      params.userId,
+      params.categoryId,
+      Object.freeze([...params.answers]),
+      params.startedAt,
+      params.completedAt,
+    );
+  }
+
+  get totalCount(): number {
+    return this.answers.length;
+  }
+
+  get correctCount(): number {
+    return this.answers.filter((a) => a.isCorrect).length;
+  }
+}

--- a/apps/api/src/domain/drill-session/query-service/drill-stats-query-service.ts
+++ b/apps/api/src/domain/drill-session/query-service/drill-stats-query-service.ts
@@ -1,0 +1,65 @@
+// --- クエリサービスが返す生データ型 ---
+
+export type LatestAnswerRow = {
+  questionId: string;
+  isCorrect: boolean;
+  categoryId: string;
+  categoryName: string;
+};
+
+export type CategoryQuestionCountRow = {
+  categoryId: string;
+  total: number;
+};
+
+export type SessionSummaryDto = {
+  sessionId: string;
+  categoryId: string | null;
+  categoryName: string | null;
+  totalCount: number;
+  correctCount: number;
+  completedAt: string;
+};
+
+// --- ユースケースが返す集計済み DTO ---
+
+export type StatsDto = {
+  totalAnswered: number;
+  correctCount: number;
+  uniqueQuestionsAnswered: number;
+  totalQuestions: number;
+};
+
+export type OverallStatsDto = StatsDto & {
+  categoryStats: Array<
+    StatsDto & {
+      categoryId: string;
+      categoryName: string;
+    }
+  >;
+};
+
+export type CategoryScoreDto = {
+  categoryId: string;
+  categoryName: string;
+  correctRate: number;
+  coverageRate: number;
+};
+
+// --- クエリサービスIF（データ取得のみ） ---
+
+export interface DrillStatsQueryService {
+  getLatestAnswers(
+    userId: string,
+    categoryId?: string,
+  ): Promise<LatestAnswerRow[]>;
+
+  getQuestionCounts(categoryId?: string): Promise<CategoryQuestionCountRow[]>;
+
+  getRecentSessions(
+    userId: string,
+    limit: number,
+    offset: number,
+    categoryId?: string,
+  ): Promise<SessionSummaryDto[]>;
+}

--- a/apps/api/src/domain/drill-session/repository/drill-session-repository.ts
+++ b/apps/api/src/domain/drill-session/repository/drill-session-repository.ts
@@ -1,0 +1,5 @@
+import type { DrillSession } from "../entity/drill-session.ts";
+
+export interface DrillSessionRepository {
+  save(session: DrillSession): Promise<void>;
+}

--- a/apps/api/src/infrastructure/db/schema.ts
+++ b/apps/api/src/infrastructure/db/schema.ts
@@ -3,12 +3,14 @@ import {
   pgEnum,
   uuid,
   varchar,
+  text,
   integer,
   jsonb,
   timestamp,
   index,
   boolean,
 } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema";
 
 export const difficultyEnum = pgEnum("difficulty", ["easy", "medium", "hard"]);
 
@@ -96,6 +98,51 @@ export const questionProposalProjections = pgTable(
   (table) => [
     index("idx_question_proposal_projections_status").on(table.status),
     index("idx_question_proposal_projections_category_id").on(table.categoryId),
+  ],
+);
+
+export const drillSessions = pgTable(
+  "drill_sessions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id),
+    /** null = 全カテゴリ横断（「すべて」選択時） */
+    categoryId: uuid("category_id").references(() => categories.id),
+    totalCount: integer("total_count").notNull(),
+    correctCount: integer("correct_count").notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull(),
+    completedAt: timestamp("completed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_drill_sessions_user_id").on(table.userId),
+    index("idx_drill_sessions_user_category").on(
+      table.userId,
+      table.categoryId,
+    ),
+    index("idx_drill_sessions_completed_at").on(table.completedAt),
+  ],
+);
+
+export const drillAnswers = pgTable(
+  "drill_answers",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => drillSessions.id),
+    questionId: uuid("question_id")
+      .notNull()
+      .references(() => questions.id),
+    selectedIndexes: integer("selected_indexes").array().notNull(),
+    isCorrect: boolean("is_correct").notNull(),
+  },
+  (table) => [
+    index("idx_drill_answers_session_id").on(table.sessionId),
+    index("idx_drill_answers_question_id").on(table.questionId),
   ],
 );
 

--- a/apps/api/src/infrastructure/drill-session/drizzle-drill-session-repository.ts
+++ b/apps/api/src/infrastructure/drill-session/drizzle-drill-session-repository.ts
@@ -1,0 +1,30 @@
+import { drillSessions, drillAnswers } from "../db/schema.ts";
+import { getCurrentTransaction } from "../db/transaction-context.ts";
+import type { DrillSession } from "../../domain/drill-session/entity/drill-session.ts";
+import type { DrillSessionRepository } from "../../domain/drill-session/repository/drill-session-repository.ts";
+
+export class DrizzleDrillSessionRepository implements DrillSessionRepository {
+  async save(session: DrillSession): Promise<void> {
+    const tx = getCurrentTransaction();
+    await tx.insert(drillSessions).values({
+      id: session.id,
+      userId: session.userId,
+      categoryId: session.categoryId,
+      totalCount: session.totalCount,
+      correctCount: session.correctCount,
+      startedAt: session.startedAt,
+      completedAt: session.completedAt,
+    });
+
+    if (session.answers.length > 0) {
+      await tx.insert(drillAnswers).values(
+        session.answers.map((a) => ({
+          sessionId: session.id,
+          questionId: a.questionId,
+          selectedIndexes: a.selectedIndexes,
+          isCorrect: a.isCorrect,
+        })),
+      );
+    }
+  }
+}

--- a/apps/api/src/infrastructure/drill-session/drizzle-drill-stats-query-service.ts
+++ b/apps/api/src/infrastructure/drill-session/drizzle-drill-stats-query-service.ts
@@ -1,0 +1,134 @@
+import { eq, and, count, desc, inArray } from "drizzle-orm";
+import {
+  drillSessions,
+  drillAnswers,
+  questions,
+  categories,
+} from "../db/schema.ts";
+import { getCurrentTransaction } from "../db/transaction-context.ts";
+import type {
+  DrillStatsQueryService,
+  LatestAnswerRow,
+  CategoryQuestionCountRow,
+  SessionSummaryDto,
+} from "../../domain/drill-session/query-service/drill-stats-query-service.ts";
+
+export class DrizzleDrillStatsQueryService implements DrillStatsQueryService {
+  async getLatestAnswers(
+    userId: string,
+    categoryId?: string,
+  ): Promise<LatestAnswerRow[]> {
+    const tx = getCurrentTransaction();
+
+    const conditions = [eq(drillSessions.userId, userId)];
+    if (categoryId) {
+      conditions.push(eq(questions.categoryId, categoryId));
+    }
+
+    return tx
+      .selectDistinctOn([drillAnswers.questionId], {
+        questionId: drillAnswers.questionId,
+        isCorrect: drillAnswers.isCorrect,
+        categoryId: questions.categoryId,
+        categoryName: categories.name,
+      })
+      .from(drillAnswers)
+      .innerJoin(drillSessions, eq(drillAnswers.sessionId, drillSessions.id))
+      .innerJoin(questions, eq(drillAnswers.questionId, questions.id))
+      .innerJoin(categories, eq(questions.categoryId, categories.id))
+      .where(and(...conditions))
+      .orderBy(drillAnswers.questionId, desc(drillSessions.completedAt));
+  }
+
+  async getQuestionCounts(
+    categoryId?: string,
+  ): Promise<CategoryQuestionCountRow[]> {
+    const tx = getCurrentTransaction();
+
+    const query = tx
+      .select({
+        categoryId: questions.categoryId,
+        total: count(questions.id),
+      })
+      .from(questions)
+      .groupBy(questions.categoryId);
+
+    if (categoryId) {
+      return query.where(eq(questions.categoryId, categoryId));
+    }
+    return query;
+  }
+
+  async getRecentSessions(
+    userId: string,
+    limit: number,
+    offset: number,
+    categoryId?: string,
+  ): Promise<SessionSummaryDto[]> {
+    const tx = getCurrentTransaction();
+
+    if (categoryId) {
+      // そのカテゴリの問題を含むセッションIDを抽出してフィルタ
+      const sessionIds = tx
+        .selectDistinct({ sessionId: drillAnswers.sessionId })
+        .from(drillAnswers)
+        .innerJoin(questions, eq(drillAnswers.questionId, questions.id))
+        .where(eq(questions.categoryId, categoryId));
+
+      const rows = await tx
+        .select({
+          sessionId: drillSessions.id,
+          categoryId: drillSessions.categoryId,
+          categoryName: categories.name,
+          totalCount: drillSessions.totalCount,
+          correctCount: drillSessions.correctCount,
+          completedAt: drillSessions.completedAt,
+        })
+        .from(drillSessions)
+        .leftJoin(categories, eq(drillSessions.categoryId, categories.id))
+        .where(
+          and(
+            eq(drillSessions.userId, userId),
+            inArray(drillSessions.id, sessionIds),
+          ),
+        )
+        .orderBy(desc(drillSessions.completedAt))
+        .limit(limit)
+        .offset(offset);
+
+      return rows.map((r) => ({
+        sessionId: r.sessionId,
+        categoryId: r.categoryId,
+        categoryName: r.categoryName,
+        totalCount: r.totalCount,
+        correctCount: r.correctCount,
+        completedAt: r.completedAt.toISOString(),
+      }));
+    }
+
+    const rows = await tx
+      .select({
+        sessionId: drillSessions.id,
+        categoryId: drillSessions.categoryId,
+        categoryName: categories.name,
+        totalCount: drillSessions.totalCount,
+        correctCount: drillSessions.correctCount,
+        completedAt: drillSessions.completedAt,
+      })
+      .from(drillSessions)
+      .leftJoin(categories, eq(drillSessions.categoryId, categories.id))
+      .where(eq(drillSessions.userId, userId))
+      .orderBy(desc(drillSessions.completedAt))
+      .limit(limit)
+      .offset(offset);
+
+    return rows.map((r) => ({
+      sessionId: r.sessionId,
+      categoryId: r.categoryId,
+      categoryName: r.categoryName,
+      totalCount: r.totalCount,
+      correctCount: r.correctCount,
+      completedAt: r.completedAt.toISOString(),
+    }));
+  }
+}

--- a/apps/api/src/presentation/routes/drill-sessions/drill-sessions.route.ts
+++ b/apps/api/src/presentation/routes/drill-sessions/drill-sessions.route.ts
@@ -1,0 +1,106 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthEnv } from "../../../infrastructure/auth/auth-middleware.ts";
+import type { Dependencies } from "../../../composition-root.ts";
+import { errorSchema } from "../shared/schema.ts";
+
+const answerSchema = z.object({
+  questionId: z.string().uuid(),
+  selectedIndexes: z.array(z.number().int().min(0)),
+  isCorrect: z.boolean(),
+});
+
+const saveDrillSessionRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["DrillSession"],
+  summary: "ドリルセッションを保存",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              categoryId: z.string().uuid().nullable(),
+              answers: z.array(answerSchema).min(1),
+              startedAt: z.string().datetime(),
+            })
+            .openapi("SaveDrillSessionRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "保存成功",
+      content: {
+        "application/json": {
+          schema: z
+            .object({ sessionId: z.string().uuid() })
+            .openapi("SaveDrillSessionResponse"),
+        },
+      },
+    },
+    400: {
+      description: "バリデーションエラー",
+      content: { "application/json": { schema: errorSchema } },
+    },
+  },
+});
+
+const recentQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  categoryId: z.string().uuid().optional(),
+});
+
+const sessionSummarySchema = z
+  .object({
+    sessionId: z.string().uuid(),
+    categoryId: z.string().uuid().nullable(),
+    categoryName: z.string().nullable(),
+    totalCount: z.number().int(),
+    correctCount: z.number().int(),
+    completedAt: z.string().datetime(),
+  })
+  .openapi("SessionSummary");
+
+const getRecentRoute = createRoute({
+  method: "get",
+  path: "/recent",
+  tags: ["DrillSession"],
+  summary: "最近のセッション一覧を取得",
+  request: { query: recentQuerySchema },
+  responses: {
+    200: {
+      description: "セッション一覧",
+      content: {
+        "application/json": { schema: z.array(sessionSummarySchema) },
+      },
+    },
+  },
+});
+
+export const createDrillSessionsRoute = (deps: Dependencies) =>
+  new OpenAPIHono<AuthEnv>()
+    .openapi(saveDrillSessionRoute, async (c) => {
+      const userId = c.get("user").id;
+      const body = c.req.valid("json");
+      const result = await deps.saveDrillSession.execute({
+        userId,
+        categoryId: body.categoryId,
+        answers: body.answers,
+        startedAt: body.startedAt,
+      });
+      return c.json(result, 201);
+    })
+    .openapi(getRecentRoute, async (c) => {
+      const userId = c.get("user").id;
+      const { limit, offset, categoryId } = c.req.valid("query");
+      const sessions = await deps.getRecentSessions.execute({
+        userId,
+        limit,
+        offset,
+        categoryId,
+      });
+      return c.json(sessions);
+    });

--- a/apps/api/src/presentation/routes/drill-stats/drill-stats.route.ts
+++ b/apps/api/src/presentation/routes/drill-stats/drill-stats.route.ts
@@ -1,0 +1,87 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthEnv } from "../../../infrastructure/auth/auth-middleware.ts";
+import type { Dependencies } from "../../../composition-root.ts";
+
+const statsQuerySchema = z.object({
+  categoryId: z.string().uuid().optional(),
+});
+
+const statsResponseSchema = z
+  .object({
+    totalAnswered: z.number().int(),
+    correctCount: z.number().int(),
+    uniqueQuestionsAnswered: z.number().int(),
+    totalQuestions: z.number().int(),
+    categoryStats: z
+      .array(
+        z.object({
+          categoryId: z.string().uuid(),
+          categoryName: z.string(),
+          totalAnswered: z.number().int(),
+          correctCount: z.number().int(),
+          uniqueQuestionsAnswered: z.number().int(),
+          totalQuestions: z.number().int(),
+        }),
+      )
+      .optional(),
+  })
+  .openapi("DrillStatsResponse");
+
+const getStatsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["DrillStats"],
+  summary: "成績統計を取得",
+  request: { query: statsQuerySchema },
+  responses: {
+    200: {
+      description: "成績統計",
+      content: { "application/json": { schema: statsResponseSchema } },
+    },
+  },
+});
+
+const categoryScoreSchema = z
+  .object({
+    categoryId: z.string().uuid(),
+    categoryName: z.string(),
+    correctRate: z.number(),
+    coverageRate: z.number(),
+  })
+  .openapi("CategoryScore");
+
+const getCategoryScoresRoute = createRoute({
+  method: "get",
+  path: "/category-scores",
+  tags: ["DrillStats"],
+  summary: "カテゴリ別スコアを取得",
+  responses: {
+    200: {
+      description: "カテゴリ別スコア",
+      content: {
+        "application/json": { schema: z.array(categoryScoreSchema) },
+      },
+    },
+  },
+});
+
+export const createDrillStatsRoute = (deps: Dependencies) =>
+  new OpenAPIHono<AuthEnv>()
+    .openapi(getStatsRoute, async (c) => {
+      const userId = c.get("user").id;
+      const { categoryId } = c.req.valid("query");
+      const stats = await deps.getDrillStats.execute({ userId, categoryId });
+      return c.json(
+        stats ?? {
+          totalAnswered: 0,
+          correctCount: 0,
+          uniqueQuestionsAnswered: 0,
+          totalQuestions: 0,
+        },
+      );
+    })
+    .openapi(getCategoryScoresRoute, async (c) => {
+      const userId = c.get("user").id;
+      const scores = await deps.getCategoryScores.execute(userId);
+      return c.json(scores);
+    });

--- a/apps/api/src/presentation/routes/index.ts
+++ b/apps/api/src/presentation/routes/index.ts
@@ -5,6 +5,8 @@ import { createQuestionsRoute } from "./questions/questions.route.ts";
 import { createQuestionProposalsRoute } from "./question-proposals/question-proposals.route.ts";
 import { createTrialRoute } from "./trial/trial.route.ts";
 import { createUserRoute } from "./user/user.route.ts";
+import { createDrillSessionsRoute } from "./drill-sessions/drill-sessions.route.ts";
+import { createDrillStatsRoute } from "./drill-stats/drill-stats.route.ts";
 import {
   requireAuth,
   requireAdmin,
@@ -44,4 +46,6 @@ export const createApiRoutes = (deps: Dependencies) =>
     .use("/question-proposals/*", requireAdmin)
     .route("/categories", createCategoriesRoute(deps))
     .route("/questions", createQuestionsRoute(deps))
-    .route("/question-proposals", createQuestionProposalsRoute(deps));
+    .route("/question-proposals", createQuestionProposalsRoute(deps))
+    .route("/drill-sessions", createDrillSessionsRoute(deps))
+    .route("/drill-stats", createDrillStatsRoute(deps));

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.1",
     "react-router-dom": "^7.13.0",
+    "recharts": "2.15.4",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "zod": "^4.3.6"

--- a/apps/web/src/components/app-layout.tsx
+++ b/apps/web/src/components/app-layout.tsx
@@ -1,5 +1,11 @@
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
-import { FlaskConical, LogOut, Shield, BookOpen } from "lucide-react";
+import {
+  FlaskConical,
+  LogOut,
+  Shield,
+  BookOpen,
+  BarChart3,
+} from "lucide-react";
 import { authClient } from "@/auth-client";
 import {
   Sidebar,
@@ -18,7 +24,10 @@ import {
 } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 
-const navItems = [{ to: "/", label: "ドリル", icon: BookOpen }];
+const navItems = [
+  { to: "/", label: "ドリル", icon: BookOpen },
+  { to: "/stats", label: "成績", icon: BarChart3 },
+];
 
 export function AppLayout() {
   const navigate = useNavigate();

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -1,0 +1,355 @@
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "@/lib/utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color,
+  );
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+  }) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color || item.payload.fill || item.color;
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                  indicator === "dot" && "items-center",
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            },
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center",
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="text-foreground font-mono font-medium tabular-nums">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+  }) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className,
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          );
+        })}
+    </div>
+  );
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string;
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+};

--- a/apps/web/src/features/drill/category-select-page.tsx
+++ b/apps/web/src/features/drill/category-select-page.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { BookOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { client } from "@/client";
 
@@ -23,6 +24,35 @@ export function CategorySelectPage() {
       return res.json();
     },
   });
+
+  const { data: categoryScores } = useQuery({
+    queryKey: ["drill-stats", "category-scores"],
+    queryFn: async () => {
+      const res = await client.api["drill-stats"]["category-scores"].$get();
+      if (!res.ok) throw new Error("Failed to fetch category scores");
+      return res.json();
+    },
+  });
+
+  const { data: overallStats } = useQuery({
+    queryKey: ["drill-stats"],
+    queryFn: async () => {
+      const res = await client.api["drill-stats"].$get({ query: {} });
+      if (!res.ok) throw new Error("Failed to fetch overall stats");
+      return res.json();
+    },
+  });
+
+  const scoreMap = new Map(categoryScores?.map((s) => [s.categoryId, s]) ?? []);
+
+  const overallCorrectRate =
+    overallStats && overallStats.totalAnswered > 0
+      ? overallStats.correctCount / overallStats.totalAnswered
+      : null;
+  const overallCoverageRate =
+    overallStats && overallStats.totalQuestions > 0
+      ? overallStats.uniqueQuestionsAnswered / overallStats.totalQuestions
+      : null;
 
   if (isLoading) {
     return (
@@ -69,29 +99,60 @@ export function CategorySelectPage() {
             <p className="text-sm text-muted-foreground">
               {totalQuestionCount} 問
             </p>
+            {overallCorrectRate !== null ? (
+              <div className="mt-2 flex gap-2">
+                <Badge variant="outline" className="text-xs">
+                  正答率 {Math.round(overallCorrectRate * 100)}%
+                </Badge>
+                <Badge variant="outline" className="text-xs">
+                  カバー率 {Math.round((overallCoverageRate ?? 0) * 100)}%
+                </Badge>
+              </div>
+            ) : (
+              <Badge variant="secondary" className="mt-2 text-xs">
+                未挑戦
+              </Badge>
+            )}
           </CardContent>
         </Card>
 
-        {categories?.map((category) => (
-          <Card
-            key={category.id}
-            className={`cursor-pointer transition-colors ${
-              selectedCategoryId === category.id
-                ? "border-primary ring-1 ring-primary"
-                : "hover:border-primary/50"
-            }`}
-            onClick={() => setSelectedCategoryId(category.id)}
-          >
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base">{category.name}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                {category.questionCount} 問
-              </p>
-            </CardContent>
-          </Card>
-        ))}
+        {categories?.map((category) => {
+          const score = scoreMap.get(category.id);
+          return (
+            <Card
+              key={category.id}
+              className={`cursor-pointer transition-colors ${
+                selectedCategoryId === category.id
+                  ? "border-primary ring-1 ring-primary"
+                  : "hover:border-primary/50"
+              }`}
+              onClick={() => setSelectedCategoryId(category.id)}
+            >
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">{category.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  {category.questionCount} 問
+                </p>
+                {score ? (
+                  <div className="mt-2 flex gap-2">
+                    <Badge variant="outline" className="text-xs">
+                      正答率 {Math.round(score.correctRate * 100)}%
+                    </Badge>
+                    <Badge variant="outline" className="text-xs">
+                      カバー率 {Math.round(score.coverageRate * 100)}%
+                    </Badge>
+                  </div>
+                ) : (
+                  <Badge variant="secondary" className="mt-2 text-xs">
+                    未挑戦
+                  </Badge>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <div className="space-y-3">

--- a/apps/web/src/features/drill/drill-page.tsx
+++ b/apps/web/src/features/drill/drill-page.tsx
@@ -55,6 +55,7 @@ export function DrillPage() {
     <div className="mx-auto w-full max-w-2xl px-4 py-8">
       <SessionContainer
         questions={data}
+        categoryId={categoryId}
         onAbort={() => navigate("/")}
         resultActions={
           <Button

--- a/apps/web/src/features/question/session-container.tsx
+++ b/apps/web/src/features/question/session-container.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { CircleStop } from "lucide-react";
 import type { QuestionDto } from "@/types/question";
 import { Button } from "@/components/ui/button";
+import { client } from "@/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,6 +21,7 @@ import { ResultScreen } from "./result-screen";
 
 type Props = {
   questions: QuestionDto[];
+  categoryId?: string;
   resultActions?: React.ReactNode;
   showRetry?: boolean;
   onAbort?: () => void;
@@ -26,6 +29,7 @@ type Props = {
 
 export function SessionContainer({
   questions,
+  categoryId,
   resultActions,
   showRetry = true,
   onAbort,
@@ -33,6 +37,33 @@ export function SessionContainer({
   const { state, selectSingle, toggleMulti, submit, next, reset } =
     useSessionReducer(questions);
   const [showAbortDialog, setShowAbortDialog] = useState(false);
+  const startedAtRef = useRef(new Date().toISOString());
+  const hasSavedRef = useRef(false);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client.api["drill-sessions"].$post({
+        json: {
+          categoryId: categoryId ?? null,
+          answers: state.results.map((r) => ({
+            questionId: r.questionId,
+            selectedIndexes: r.selectedIndexes,
+            isCorrect: r.isCorrect,
+          })),
+          startedAt: startedAtRef.current,
+        },
+      });
+      if (!res.ok) throw new Error("Failed to save session");
+      return res.json();
+    },
+  });
+
+  useEffect(() => {
+    if (state.phase === "completed" && !hasSavedRef.current) {
+      hasSavedRef.current = true;
+      saveMutation.mutate();
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (state.phase === "completed") {
     return (

--- a/apps/web/src/features/stats/category-stats-list.tsx
+++ b/apps/web/src/features/stats/category-stats-list.tsx
@@ -1,0 +1,95 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Progress } from "@/components/ui/progress";
+
+type CategoryStat = {
+  categoryId: string;
+  categoryName: string;
+  totalAnswered: number;
+  correctCount: number;
+  uniqueQuestionsAnswered: number;
+  totalQuestions: number;
+};
+
+type Props = {
+  categoryStats: CategoryStat[];
+};
+
+export function CategoryStatsList({ categoryStats }: Props) {
+  if (categoryStats.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">カテゴリ別成績</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>カテゴリ</TableHead>
+              <TableHead className="text-right">正答率</TableHead>
+              <TableHead className="text-right">カバー率</TableHead>
+              <TableHead className="text-right">回答数</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {categoryStats.map((stat) => {
+              const correctRate =
+                stat.totalAnswered > 0
+                  ? Math.round((stat.correctCount / stat.totalAnswered) * 100)
+                  : 0;
+              const coverageRate =
+                stat.totalQuestions > 0
+                  ? Math.round(
+                      (stat.uniqueQuestionsAnswered / stat.totalQuestions) *
+                        100,
+                    )
+                  : 0;
+
+              return (
+                <TableRow key={stat.categoryId}>
+                  <TableCell className="font-medium">
+                    {stat.categoryName}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <Progress
+                        value={correctRate}
+                        className="w-16 [&>*]:bg-[oklch(0.723_0.219_149.579)]"
+                      />
+                      <span className="w-10 text-sm tabular-nums">
+                        {correctRate}%
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <Progress
+                        value={coverageRate}
+                        className="w-16 [&>*]:bg-[oklch(0.623_0.214_259.815)]"
+                      />
+                      <span className="w-10 text-sm tabular-nums">
+                        {coverageRate}%
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {stat.totalAnswered}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/stats/recent-sessions.tsx
+++ b/apps/web/src/features/stats/recent-sessions.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { client } from "@/client";
+
+type Props = {
+  categoryId?: string;
+};
+
+const PAGE_SIZE = 10;
+
+export function RecentSessions({ categoryId }: Props) {
+  const [offset, setOffset] = useState(0);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["drill-sessions", "recent", categoryId, offset],
+    queryFn: async () => {
+      const query: Record<string, string> = {
+        limit: String(PAGE_SIZE + 1),
+        offset: String(offset),
+      };
+      if (categoryId) query.categoryId = categoryId;
+      const res = await client.api["drill-sessions"].recent.$get({ query });
+      if (!res.ok) throw new Error("Failed to fetch recent sessions");
+      return res.json();
+    },
+  });
+
+  const sessions = data?.slice(0, PAGE_SIZE) ?? [];
+  const hasMore = (data?.length ?? 0) > PAGE_SIZE;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">最近のセッション</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
+        )}
+        {!isLoading && sessions.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            セッション履歴がありません
+          </p>
+        )}
+        <div className="space-y-3">
+          {sessions.map((session) => {
+            const rate =
+              session.totalCount > 0
+                ? Math.round((session.correctCount / session.totalCount) * 100)
+                : 0;
+            const date = new Date(session.completedAt);
+            return (
+              <div
+                key={session.sessionId}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-xs">
+                      {session.categoryName ?? "すべて"}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {date.toLocaleDateString("ja-JP")}{" "}
+                      {date.toLocaleTimeString("ja-JP", {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+                  <p className="text-sm">
+                    {session.correctCount}/{session.totalCount} 問正解
+                  </p>
+                </div>
+                <div className="text-right">
+                  <span
+                    className={`text-lg font-bold tabular-nums ${
+                      rate >= 80
+                        ? "text-green-600"
+                        : rate >= 50
+                          ? "text-yellow-600"
+                          : "text-red-600"
+                    }`}
+                  >
+                    {rate}%
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-4 flex justify-center gap-2">
+          {offset > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              前へ
+            </Button>
+          )}
+          {hasMore && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              もっと見る
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/stats/stats-page.tsx
+++ b/apps/web/src/features/stats/stats-page.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { client } from "@/client";
+import { StatsRadialChart } from "./stats-radial-chart";
+import { CategoryStatsList } from "./category-stats-list";
+import { RecentSessions } from "./recent-sessions";
+
+const ALL_CATEGORIES = "__all__";
+
+export function StatsPage() {
+  const [selectedCategoryId, setSelectedCategoryId] = useState(ALL_CATEGORIES);
+
+  const { data: categories } = useQuery({
+    queryKey: ["categories"],
+    queryFn: async () => {
+      const res = await client.api.categories.$get();
+      if (!res.ok) throw new Error("Failed to fetch categories");
+      return res.json();
+    },
+  });
+
+  const categoryId =
+    selectedCategoryId === ALL_CATEGORIES ? undefined : selectedCategoryId;
+
+  const { data: stats, isLoading } = useQuery({
+    queryKey: ["drill-stats", categoryId],
+    queryFn: async () => {
+      const query: Record<string, string> = {};
+      if (categoryId) query.categoryId = categoryId;
+      const res = await client.api["drill-stats"].$get({ query });
+      if (!res.ok) throw new Error("Failed to fetch stats");
+      return res.json();
+    },
+  });
+
+  const correctRate =
+    stats && stats.totalAnswered > 0
+      ? stats.correctCount / stats.totalAnswered
+      : 0;
+  const coverageRate =
+    stats && stats.totalQuestions > 0
+      ? stats.uniqueQuestionsAnswered / stats.totalQuestions
+      : 0;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">成績</h2>
+        <Select
+          value={selectedCategoryId}
+          onValueChange={setSelectedCategoryId}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_CATEGORIES}>すべて</SelectItem>
+            {categories?.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : stats && stats.totalAnswered > 0 ? (
+        <div className="space-y-6">
+          <StatsRadialChart
+            correctRate={correctRate}
+            coverageRate={coverageRate}
+          />
+
+          <div className="grid grid-cols-2 gap-4 text-center">
+            <div className="rounded-lg border p-4">
+              <p className="text-2xl font-bold tabular-nums">
+                {stats.totalAnswered}
+              </p>
+              <p className="text-xs text-muted-foreground">総回答数</p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <p className="text-2xl font-bold tabular-nums">
+                {stats.uniqueQuestionsAnswered}/{stats.totalQuestions}
+              </p>
+              <p className="text-xs text-muted-foreground">問題カバー数</p>
+            </div>
+          </div>
+
+          {"categoryStats" in stats &&
+            stats.categoryStats &&
+            stats.categoryStats.length > 0 && (
+              <CategoryStatsList categoryStats={stats.categoryStats} />
+            )}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-muted-foreground">まだ回答データがありません</p>
+          <p className="text-sm text-muted-foreground">
+            ドリルを完了すると成績が表示されます
+          </p>
+        </div>
+      )}
+
+      <RecentSessions categoryId={categoryId} />
+    </div>
+  );
+}

--- a/apps/web/src/features/stats/stats-radial-chart.tsx
+++ b/apps/web/src/features/stats/stats-radial-chart.tsx
@@ -1,0 +1,140 @@
+import {
+  Label,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart,
+} from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  correctRate: number;
+  coverageRate: number;
+};
+
+const chartConfig = {
+  correctRate: {
+    label: "正答率",
+    color: "oklch(0.723 0.219 149.579)",
+  },
+  coverageRate: {
+    label: "カバー率",
+    color: "oklch(0.623 0.214 259.815)",
+  },
+} satisfies ChartConfig;
+
+export function StatsRadialChart({ correctRate, coverageRate }: Props) {
+  const data = [
+    {
+      name: "カバー率",
+      value: Math.round(coverageRate * 100),
+      fill: "var(--color-coverageRate)",
+    },
+    {
+      name: "正答率",
+      value: Math.round(correctRate * 100),
+      fill: "var(--color-correctRate)",
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">総合スコア</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={chartConfig}
+          className="mx-auto aspect-square max-h-[250px]"
+        >
+          <RadialBarChart
+            data={data}
+            innerRadius={60}
+            outerRadius={110}
+            startAngle={90}
+            endAngle={-270}
+          >
+            <PolarGrid gridType="circle" radialLines={false} stroke="none" />
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+            <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
+              <Label
+                content={({ viewBox }) => {
+                  if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                    return (
+                      <text
+                        x={viewBox.cx}
+                        y={viewBox.cy}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                      >
+                        <tspan
+                          x={viewBox.cx}
+                          y={(viewBox.cy ?? 0) - 8}
+                          className="fill-foreground text-2xl font-bold"
+                        >
+                          {Math.round(correctRate * 100)}%
+                        </tspan>
+                        <tspan
+                          x={viewBox.cx}
+                          y={(viewBox.cy ?? 0) + 14}
+                          className="fill-muted-foreground text-xs"
+                        >
+                          正答率
+                        </tspan>
+                      </text>
+                    );
+                  }
+                }}
+              />
+            </PolarRadiusAxis>
+            <RadialBar
+              dataKey="value"
+              cornerRadius={5}
+              background={{ fill: "hsl(var(--muted))" }}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  hideLabel
+                  formatter={(value, name) => (
+                    <span>
+                      {name}: {String(value)}%
+                    </span>
+                  )}
+                />
+              }
+            />
+          </RadialBarChart>
+        </ChartContainer>
+        <div className="flex justify-center gap-6 text-sm">
+          <div className="flex items-center gap-1.5">
+            <div
+              className="size-3 rounded-full"
+              style={{ backgroundColor: chartConfig.correctRate.color }}
+            />
+            <span className="text-muted-foreground">
+              正答率: {Math.round(correctRate * 100)}%
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div
+              className="size-3 rounded-full"
+              style={{ backgroundColor: chartConfig.coverageRate.color }}
+            />
+            <span className="text-muted-foreground">
+              カバー率: {Math.round(coverageRate * 100)}%
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -19,6 +19,7 @@ import { QuestionListPage } from "./features/admin/questions/question-list-page"
 import { QuestionDetailPage } from "./features/admin/questions/question-detail-page";
 import { CategorySelectPage } from "./features/drill/category-select-page";
 import { DrillPage } from "./features/drill/drill-page";
+import { StatsPage } from "./features/stats/stats-page";
 import "./index.css";
 
 function Root() {
@@ -36,6 +37,7 @@ function Root() {
             <Route element={<AppLayout />}>
               <Route path="/" element={<CategorySelectPage />} />
               <Route path="/drill" element={<DrillPage />} />
+              <Route path="/stats" element={<StatsPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
             <Route element={<AdminRoute />}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts:
+        specifier: 2.15.4
+        version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -383,6 +386,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -2304,6 +2311,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2638,6 +2672,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -2651,6 +2729,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2663,6 +2744,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
@@ -2877,6 +2961,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2889,6 +2976,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -3039,6 +3130,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3209,12 +3304,19 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3284,6 +3386,10 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3362,6 +3468,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -3393,6 +3502,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -3435,6 +3550,12 @@ packages:
       react-dom:
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -3445,9 +3566,25 @@ packages:
       '@types/react':
         optional: true
 
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3586,6 +3723,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3713,6 +3853,9 @@ packages:
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -4357,6 +4500,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -6092,6 +6237,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -6408,11 +6577,51 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -6421,6 +6630,11 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      csstype: 3.2.3
 
   drizzle-kit@0.30.6:
     dependencies:
@@ -6669,6 +6883,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
@@ -6676,6 +6892,8 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -6832,6 +7050,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  internmap@2.0.3: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -6976,6 +7196,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.23: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.2.0
@@ -6985,6 +7207,10 @@ snapshots:
       wrap-ansi: 9.0.2
 
   long@5.3.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
 
@@ -7038,6 +7264,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.27: {}
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -7102,6 +7330,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   protobufjs@7.5.4:
     dependencies:
@@ -7192,6 +7426,10 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
+
   react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.11)(react@19.2.4):
@@ -7227,6 +7465,14 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
+  react-smooth@4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
   react-style-singleton@2.2.3(@types/react@19.2.11)(react@19.2.4):
     dependencies:
       get-nonce: 1.0.1
@@ -7235,7 +7481,33 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.11
 
+  react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   resolve-from@4.0.0: {}
 
@@ -7374,6 +7646,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -7482,6 +7756,23 @@ snapshots:
       react: 19.2.4
 
   uuid@13.0.0: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- ドリルの回答結果をサーバーに保存し、成績を可視化する機能を追加
- DB に `drill_sessions` / `drill_answers` テーブルを追加し、セッション完了時に自動保存
- 各問題の最新回答のみで正答率・カバー率を算出（`DISTINCT ON` による最新回答抽出）
- 成績ページ（円グラフ・カテゴリ別成績・セッション履歴）を新設
- カテゴリ選択画面にスコア（正答率・カバー率）を表示
- API を `drill-sessions`（リソース操作）と `drill-stats`（統計）に分離
- クエリサービスはデータ取得のみ、集計ロジックはユースケース層に配置

## Test plan

- [ ] ログインしてドリルを1セッション完了 → DB に drill_sessions/drill_answers が保存されることを確認
- [ ] 同じ問題を正解→不正解→正解と解いた場合、最新の正解が正答率に反映されることを確認
- [ ] カテゴリ選択画面でスコア（正答率・カバー率）が表示されることを確認
- [ ] 「すべて」で出題したセッションが、カテゴリ別フィルタでも表示されることを確認
- [ ] サイドメニュー「成績」→ 成績ページで円グラフ・カテゴリ別・セッション履歴が表示されることを確認
- [ ] カテゴリ絞り込みが動作することを確認
- [ ] `pnpm lint && pnpm build` が通ることを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)