### PR TITLE
feat: アカウント設定ページの追加

### DIFF
--- a/apps/web/src/components/app-layout.tsx
+++ b/apps/web/src/components/app-layout.tsx
@@ -5,6 +5,7 @@ import {
   Shield,
   BookOpen,
   BarChart3,
+  Settings,
 } from "lucide-react";
 import { authClient } from "@/auth-client";
 import {
@@ -93,6 +94,18 @@ export function AppLayout() {
               </SidebarMenuItem>
             )}
             <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={location.pathname === "/account"}
+                tooltip="アカウント設定"
+              >
+                <Link to="/account">
+                  <Settings />
+                  <span>アカウント設定</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
               <SidebarMenuButton onClick={handleSignOut} tooltip="ログアウト">
                 <LogOut />
                 <span>ログアウト</span>
@@ -106,15 +119,15 @@ export function AppLayout() {
           <SidebarTrigger />
           <Separator orientation="vertical" className="mr-2 h-4" />
           <span className="text-sm font-medium text-muted-foreground">
-            {
-              navItems.find(
-                (item) =>
-                  location.pathname === item.to ||
-                  location.pathname.startsWith(
-                    item.to === "/" ? "/drill" : item.to,
-                  ),
-              )?.label
-            }
+            {location.pathname === "/account"
+              ? "アカウント設定"
+              : navItems.find(
+                  (item) =>
+                    location.pathname === item.to ||
+                    location.pathname.startsWith(
+                      item.to === "/" ? "/drill" : item.to,
+                    ),
+                )?.label}
           </span>
         </header>
         <div className="flex flex-1 flex-col p-4">

--- a/apps/web/src/features/account/account-page.tsx
+++ b/apps/web/src/features/account/account-page.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { User, AtSign, Mail, Loader2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/auth-client";
+import { client } from "@/client";
+
+const usernamePattern = /^[a-z0-9_-]{3,20}$/;
+
+function AccountForm({
+  user,
+}: {
+  user: { name: string; username: string | null; email: string };
+}) {
+  const [name, setName] = useState(user.name);
+  const [username, setUsername] = useState(user.username ?? "");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isUsernameValid = usernamePattern.test(username);
+  const hasChanges = name !== user.name || username !== (user.username ?? "");
+
+  const handleSubmit = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    setIsLoading(true);
+
+    if (username !== (user.username ?? "")) {
+      try {
+        const res = await client.api.user["check-username"].$get({
+          query: { username },
+        });
+        const { available } = await res.json();
+        if (!available) {
+          setIsLoading(false);
+          setError("このユーザー名は既に使われています。");
+          return;
+        }
+      } catch {
+        setIsLoading(false);
+        setError("ユーザー名の確認に失敗しました。");
+        return;
+      }
+    }
+
+    const { error } = await authClient.updateUser({ name, username });
+
+    if (error) {
+      setIsLoading(false);
+      setError("更新に失敗しました。");
+      return;
+    }
+
+    await authClient.getSession();
+    setIsLoading(false);
+    setSuccess("アカウント情報を更新しました。");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="relative">
+        <User className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+        <Input
+          type="text"
+          placeholder="名前"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setSuccess("");
+          }}
+          required
+          className="pl-10"
+        />
+      </div>
+      <div>
+        <div className="relative">
+          <AtSign className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+          <Input
+            type="text"
+            placeholder="ユーザー名（例: taro_123）"
+            value={username}
+            onChange={(e) => {
+              setUsername(e.target.value.toLowerCase());
+              setSuccess("");
+            }}
+            required
+            className="pl-10"
+          />
+        </div>
+        {username && !isUsernameValid && (
+          <p className="text-destructive text-xs mt-1">
+            3〜20文字の英小文字・数字・_・- で入力してください
+          </p>
+        )}
+      </div>
+      <div className="relative">
+        <Mail className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+        <Input type="email" value={user.email} disabled className="pl-10" />
+      </div>
+      {error && <p className="text-destructive text-sm">{error}</p>}
+      {success && (
+        <p className="text-sm text-green-600 flex items-center gap-1">
+          <Check className="size-4" />
+          {success}
+        </p>
+      )}
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={isLoading || !name.trim() || !isUsernameValid || !hasChanges}
+      >
+        {isLoading ? <Loader2 className="animate-spin" /> : "保存"}
+      </Button>
+    </form>
+  );
+}
+
+export function AccountPage() {
+  const { data: session } = authClient.useSession();
+
+  return (
+    <div className="flex justify-center">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">アカウント設定</CardTitle>
+          <CardDescription>表示名とユーザー名を変更できます</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {session?.user && <AccountForm user={session.user} />}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -20,6 +20,7 @@ import { QuestionDetailPage } from "./features/admin/questions/question-detail-p
 import { CategorySelectPage } from "./features/drill/category-select-page";
 import { DrillPage } from "./features/drill/drill-page";
 import { StatsPage } from "./features/stats/stats-page";
+import { AccountPage } from "./features/account/account-page";
 import "./index.css";
 
 function Root() {
@@ -38,6 +39,7 @@ function Root() {
               <Route path="/" element={<CategorySelectPage />} />
               <Route path="/drill" element={<DrillPage />} />
               <Route path="/stats" element={<StatsPage />} />
+              <Route path="/account" element={<AccountPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
             <Route element={<AdminRoute />}>


### PR DESCRIPTION
## Summary

- ログイン済みユーザーが表示名（name）とユーザー名（username）を編集できるアカウント設定ページを新設
- サイドバーフッターに「アカウント設定」リンクを追加（管理画面とログアウトの間）
- username 変更時は既存の `check-username` API で重複チェック、バリデーション（`/^[a-z0-9_-]{3,20}$/`）も実装

## Test plan

- [ ] ログイン後、サイドバーフッターに「アカウント設定」リンクが表示される
- [ ] `/account` ページで現在の name, username, email が表示される
- [ ] name と username を変更して保存し、反映される
- [ ] 既に使われている username を入力した際にエラーが表示される
- [ ] 不正な形式の username を入力した際にバリデーションエラーが表示される
- [ ] ヘッダーに「アカウント設定」と表示される

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)