### PR TITLE
feat: カスタムドメイン設定

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -31,9 +31,15 @@ export default $config({
 
     // --- API Gateway (HTTP API) ---
     const api = new sst.aws.ApiGatewayV2("Api", {
+      cors: false,
       domain: {
         name: apiDomain,
         dns: sst.aws.dns(),
+      },
+      transform: {
+        api: {
+          corsConfiguration: undefined,
+        },
       },
     });
 
@@ -66,8 +72,8 @@ export default $config({
         DATABASE_URL: databaseUrl.value,
         GEMINI_API_KEY: geminiApiKey.value,
         BETTER_AUTH_SECRET: betterAuthSecret.value,
-        BETTER_AUTH_URL: api.url,
-        CORS_ORIGIN: site.url,
+        BETTER_AUTH_URL: `https://${apiDomain}`,
+        CORS_ORIGIN: `https://${siteDomain}`,
         SES_FROM_EMAIL: sesFromEmail.value,
       },
       nodejs: {


### PR DESCRIPTION
## Summary

- API Gateway と CloudFront にカスタムドメインを設定
- production: `chem-drill.com` / `api.chem-drill.com`
- dev: `dev.chem-drill.com` / `api.dev.chem-drill.com`

## 変更内容

`sst.config.ts` に SST の `domain` プロパティを追加。ACM 証明書の発行・DNS レコード作成は SST が自動で行うため、アプリケーションコードの変更は不要。

## Test plan

- [x] `pnpm sst:deploy --stage dev` でデプロイ成功
- [x] `https://dev.chem-drill.com` にアクセスしフロントエンドが表示される
- [x] `https://api.dev.chem-drill.com/api/health` で API が応答する
- [x] ログイン・ログアウトが正常に動作する（CORS / Cookie の動作確認）

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)