### PR TITLE
feat: 管理画面にユーザー一覧ページを追加

### DIFF
--- a/apps/api/src/application/user/list-users.ts
+++ b/apps/api/src/application/user/list-users.ts
@@ -1,0 +1,22 @@
+import type {
+  UserQueryService,
+  ListUsersResult,
+} from "../../domain/user/query-service/user-query-service.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+export class ListUsers {
+  constructor(
+    private uow: UnitOfWork,
+    private userQueryService: UserQueryService,
+  ) {}
+
+  async execute(
+    search: string | undefined,
+    limit: number,
+    offset: number,
+  ): Promise<ListUsersResult> {
+    return this.uow.run(async () => {
+      return await this.userQueryService.listUsers(search, limit, offset);
+    });
+  }
+}

--- a/apps/api/src/composition-root.ts
+++ b/apps/api/src/composition-root.ts
@@ -25,6 +25,7 @@ import { DrizzleQuestionProposalRepository } from "./infrastructure/question-pro
 import { DrizzleQuestionProposalProjectionQueryService } from "./infrastructure/question-proposal/drizzle-question-proposal-projection-query-service.ts";
 import { DrizzleUserQueryService } from "./infrastructure/user/drizzle-user-query-service.ts";
 import { CheckUsernameAvailability } from "./application/user/check-username-availability.ts";
+import { ListUsers } from "./application/user/list-users.ts";
 import { CategoryNameDuplicateChecker } from "./domain/category/service/category-name-duplicate-checker.ts";
 import { CategoryDeletionPolicy } from "./domain/category/service/category-deletion-policy.ts";
 import { OnQuestionProposalApproved } from "./application/question-proposal/on-question-proposal-approved.ts";
@@ -149,6 +150,8 @@ const checkUsernameAvailability = new CheckUsernameAvailability(
   userQueryService,
 );
 
+const listUsers = new ListUsers(unitOfWork, userQueryService);
+
 const uploadIcon = new UploadIcon(iconStorage, iconProcessor);
 const deleteIcon = new DeleteIcon(iconStorage);
 
@@ -168,6 +171,7 @@ const getCategoryScores = new GetCategoryScores(
 
 export const dependencies = {
   checkUsernameAvailability,
+  listUsers,
   uploadIcon,
   deleteIcon,
   getRandomQuestions,

--- a/apps/api/src/domain/user/query-service/user-query-service.ts
+++ b/apps/api/src/domain/user/query-service/user-query-service.ts
@@ -1,3 +1,24 @@
+export type UserListItemDto = {
+  id: string;
+  name: string;
+  email: string;
+  username: string | null;
+  role: string;
+  image: string | null;
+  createdAt: Date;
+  lastLoginAt: Date | null;
+};
+
+export type ListUsersResult = {
+  items: UserListItemDto[];
+  total: number;
+};
+
 export interface UserQueryService {
   isUsernameAvailable(username: string): Promise<boolean>;
+  listUsers(
+    search: string | undefined,
+    limit: number,
+    offset: number,
+  ): Promise<ListUsersResult>;
 }

--- a/apps/api/src/infrastructure/user/drizzle-user-query-service.ts
+++ b/apps/api/src/infrastructure/user/drizzle-user-query-service.ts
@@ -1,7 +1,10 @@
-import { eq } from "drizzle-orm";
-import { user } from "../db/auth-schema.ts";
+import { eq, ilike, or, desc, count, max } from "drizzle-orm";
+import { user, session } from "../db/auth-schema.ts";
 import { getCurrentTransaction } from "../db/transaction-context.ts";
-import type { UserQueryService } from "../../domain/user/query-service/user-query-service.ts";
+import type {
+  UserQueryService,
+  ListUsersResult,
+} from "../../domain/user/query-service/user-query-service.ts";
 
 export class DrizzleUserQueryService implements UserQueryService {
   async isUsernameAvailable(username: string): Promise<boolean> {
@@ -12,5 +15,68 @@ export class DrizzleUserQueryService implements UserQueryService {
       .where(eq(user.username, username))
       .limit(1);
     return rows.length === 0;
+  }
+
+  async listUsers(
+    search: string | undefined,
+    limit: number,
+    offset: number,
+  ): Promise<ListUsersResult> {
+    const tx = getCurrentTransaction();
+
+    const lastLoginSubquery = tx
+      .select({
+        userId: session.userId,
+        lastLoginAt: max(session.createdAt).as("last_login_at"),
+      })
+      .from(session)
+      .groupBy(session.userId)
+      .as("last_login");
+
+    const escapedSearch = search
+      ? search.replace(/[%_\\]/g, (ch) => `\\${ch}`)
+      : undefined;
+
+    const conditions = escapedSearch
+      ? or(
+          ilike(user.name, `%${escapedSearch}%`),
+          ilike(user.email, `%${escapedSearch}%`),
+        )
+      : undefined;
+
+    const [items, totalResult] = await Promise.all([
+      tx
+        .select({
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          username: user.username,
+          role: user.role,
+          image: user.image,
+          createdAt: user.createdAt,
+          lastLoginAt: lastLoginSubquery.lastLoginAt,
+        })
+        .from(user)
+        .leftJoin(lastLoginSubquery, eq(user.id, lastLoginSubquery.userId))
+        .where(conditions)
+        .orderBy(desc(user.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(user).where(conditions),
+    ]);
+
+    return {
+      items: items.map((row) => ({
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        username: row.username,
+        role: row.role,
+        image: row.image,
+        createdAt: row.createdAt,
+        lastLoginAt: row.lastLoginAt ? new Date(row.lastLoginAt) : null,
+      })),
+      total: totalResult[0]?.count ?? 0,
+    };
   }
 }

--- a/apps/api/src/presentation/routes/admin/users.route.ts
+++ b/apps/api/src/presentation/routes/admin/users.route.ts
@@ -1,0 +1,61 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { Dependencies } from "../../../composition-root.ts";
+
+const userListItemSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    email: z.string(),
+    username: z.string().nullable(),
+    role: z.string(),
+    image: z.string().nullable(),
+    createdAt: z.string(),
+    lastLoginAt: z.string().nullable(),
+  })
+  .openapi("AdminUserListItem");
+
+const listUsersRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Admin"],
+  summary: "ユーザー一覧を取得",
+  request: {
+    query: z.object({
+      search: z.string().optional(),
+      limit: z.coerce.number().int().min(1).max(100).default(20),
+      offset: z.coerce.number().int().min(0).default(0),
+    }),
+  },
+  responses: {
+    200: {
+      description: "ユーザー一覧",
+      content: {
+        "application/json": {
+          schema: z.object({
+            items: z.array(userListItemSchema),
+            total: z.number().int(),
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const createAdminUsersRoute = (deps: Dependencies) =>
+  new OpenAPIHono().openapi(listUsersRoute, async (c) => {
+    const { search, limit, offset } = c.req.valid("query");
+    const result = await deps.listUsers.execute(search, limit, offset);
+    return c.json({
+      items: result.items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        email: item.email,
+        username: item.username,
+        role: item.role,
+        image: item.image,
+        createdAt: item.createdAt.toISOString(),
+        lastLoginAt: item.lastLoginAt?.toISOString() ?? null,
+      })),
+      total: result.total,
+    });
+  });

--- a/apps/api/src/presentation/routes/index.ts
+++ b/apps/api/src/presentation/routes/index.ts
@@ -7,6 +7,7 @@ import { createTrialRoute } from "./trial/trial.route.ts";
 import { createUserRoute } from "./user/user.route.ts";
 import { createDrillSessionsRoute } from "./drill-sessions/drill-sessions.route.ts";
 import { createDrillStatsRoute } from "./drill-stats/drill-stats.route.ts";
+import { createAdminUsersRoute } from "./admin/users.route.ts";
 import {
   requireAuth,
   requireAdmin,
@@ -44,8 +45,10 @@ export const createApiRoutes = (deps: Dependencies) =>
       return requireAdmin(c, next);
     })
     .use("/question-proposals/*", requireAdmin)
+    .use("/admin/*", requireAdmin)
     .route("/categories", createCategoriesRoute(deps))
     .route("/questions", createQuestionsRoute(deps))
     .route("/question-proposals", createQuestionProposalsRoute(deps))
+    .route("/admin/users", createAdminUsersRoute(deps))
     .route("/drill-sessions", createDrillSessionsRoute(deps))
     .route("/drill-stats", createDrillStatsRoute(deps));

--- a/apps/web/src/features/admin/admin-layout.tsx
+++ b/apps/web/src/features/admin/admin-layout.tsx
@@ -3,6 +3,7 @@ import {
   FileText,
   FolderOpen,
   BookOpen,
+  Users,
   ArrowLeft,
   LogOut,
   Shield,
@@ -14,6 +15,7 @@ const navItems = [
   { to: "/admin/proposals", label: "出題案", icon: FileText },
   { to: "/admin/questions", label: "問題", icon: BookOpen },
   { to: "/admin/categories", label: "カテゴリ", icon: FolderOpen },
+  { to: "/admin/users", label: "ユーザー", icon: Users },
 ];
 
 export function AdminLayout() {

--- a/apps/web/src/features/admin/users/user-list-page.tsx
+++ b/apps/web/src/features/admin/users/user-list-page.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { Search } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { UserIcon } from "@/components/user-icon";
+import { client } from "@/client";
+
+const PAGE_SIZE = 20;
+
+const roleLabels: Record<string, string> = {
+  admin: "管理者",
+  user: "ユーザー",
+};
+
+export function UserListPage() {
+  const [search, setSearch] = useState("");
+  const [submittedSearch, setSubmittedSearch] = useState("");
+  const [offset, setOffset] = useState(0);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin-users", submittedSearch, offset],
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const query: Record<string, string> = {
+        limit: String(PAGE_SIZE),
+        offset: String(offset),
+      };
+      if (submittedSearch) {
+        query.search = submittedSearch;
+      }
+      const res = await client.api.admin.users.$get({ query });
+      if (!res.ok) throw new Error("Failed to fetch users");
+      return res.json();
+    },
+  });
+
+  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  const handleSearch = () => {
+    setSubmittedSearch(search);
+    setOffset(0);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold tracking-tight">ユーザー</h2>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSearch();
+          }}
+        >
+          <Input
+            placeholder="名前・メールで検索..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-64"
+          />
+          <Button type="submit" variant="outline" size="icon">
+            <Search className="size-4" />
+          </Button>
+        </form>
+        {data && (
+          <span className="text-sm text-muted-foreground">{data.total} 件</span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">読み込み中...</p>
+      ) : (
+        <>
+          <div className="rounded-md border bg-background">
+            <Table>
+              <TableHeader className="bg-primary/10">
+                <TableRow className="border-b-2 border-primary/30">
+                  <TableHead className="w-10 font-bold text-primary" />
+                  <TableHead className="font-bold text-primary">名前</TableHead>
+                  <TableHead className="font-bold text-primary">
+                    ユーザー名
+                  </TableHead>
+                  <TableHead className="font-bold text-primary">
+                    メール
+                  </TableHead>
+                  <TableHead className="font-bold text-primary">
+                    ロール
+                  </TableHead>
+                  <TableHead className="font-bold text-primary">
+                    登録日
+                  </TableHead>
+                  <TableHead className="font-bold text-primary">
+                    最終ログイン
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.items.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="text-center text-muted-foreground"
+                    >
+                      ユーザーが見つかりません
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  data?.items.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell>
+                        <UserIcon
+                          name={item.name}
+                          image={item.image}
+                          size="sm"
+                        />
+                      </TableCell>
+                      <TableCell className="font-medium">{item.name}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {item.username ?? "-"}
+                      </TableCell>
+                      <TableCell className="text-sm">{item.email}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            item.role === "admin" ? "default" : "secondary"
+                          }
+                        >
+                          {roleLabels[item.role] ?? item.role}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {new Date(item.createdAt).toLocaleDateString("ja-JP")}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {item.lastLoginAt
+                          ? new Date(item.lastLoginAt).toLocaleDateString(
+                              "ja-JP",
+                            )
+                          : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset === 0}
+                onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+              >
+                前へ
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {currentPage} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage >= totalPages}
+                onClick={() => setOffset((o) => o + PAGE_SIZE)}
+              >
+                次へ
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -17,6 +17,7 @@ import { ProposalDetailPage } from "./features/admin/proposals/proposal-detail-p
 import { CategoryListPage } from "./features/admin/categories/category-list-page";
 import { QuestionListPage } from "./features/admin/questions/question-list-page";
 import { QuestionDetailPage } from "./features/admin/questions/question-detail-page";
+import { UserListPage } from "./features/admin/users/user-list-page";
 import { CategorySelectPage } from "./features/drill/category-select-page";
 import { DrillPage } from "./features/drill/drill-page";
 import { StatsPage } from "./features/stats/stats-page";
@@ -55,6 +56,7 @@ function Root() {
                 <Route path="questions" element={<QuestionListPage />} />
                 <Route path="questions/:id" element={<QuestionDetailPage />} />
                 <Route path="categories" element={<CategoryListPage />} />
+                <Route path="users" element={<UserListPage />} />
               </Route>
             </Route>
           </Route>


### PR DESCRIPTION
## Summary

- 管理画面に「ユーザー」セクションを追加し、登録ユーザーの一覧（アイコン・名前・ユーザー名・メール・ロール・登録日・最終ログイン）をテキスト検索・ページネーション付きで閲覧できるようにする
- `GET /api/admin/users` エンドポイントを新設（`requireAdmin` ミドルウェアで保護）
- session テーブルから最終ログイン日時を取得するサブクエリを LEFT JOIN

## 変更内容

### バックエンド
- `UserQueryService` に `listUsers` メソッドを追加（ドメイン層）
- `DrizzleUserQueryService` に Drizzle 実装を追加（ILIKE 検索 + ページネーション + 最終ログインサブクエリ）
- `ListUsers` ユースケースを新規作成
- `admin/users.route.ts` に OpenAPI ルートを新規作成
- `/admin/*` に `requireAdmin` ミドルウェアを適用

### フロントエンド
- `user-list-page.tsx` を新規作成（テーブル表示・検索・ページネーション）
- 管理画面サイドバーに「ユーザー」ナビリンクを追加
- `/admin/users` ルートを追加

## Test plan

- [ ] admin ユーザーでログイン後、管理画面サイドバーに「ユーザー」リンクが表示される
- [ ] `/admin/users` でユーザー一覧が表示される（アイコン・名前・ユーザー名・メール・ロール・登録日・最終ログイン）
- [ ] テキスト検索で名前・メールによるフィルタが機能する
- [ ] ページネーションが正しく動作する
- [ ] 一般ユーザーで `/api/admin/users` にアクセスすると 403 になる
- [ ] `pnpm lint` / `pnpm build` が通る

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)