### PR TITLE
docs: インフラ構成図を追加

### DIFF
--- a/docs/infrastructure.drawio
+++ b/docs/infrastructure.drawio
@@ -1,0 +1,94 @@
+<mxfile host="65bd71144e">
+    <diagram id="infra" name="Infrastructure">
+        <mxGraphModel dx="1127" dy="663" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1550" pageHeight="900" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="users" value="Users / Browser" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#232F3E;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.users;" parent="1" vertex="1">
+                    <mxGeometry x="601" y="30" width="58" height="58" as="geometry"/>
+                </mxCell>
+                <mxCell id="aws-cloud" value="AWS Cloud&amp;nbsp; (ap-northeast-1)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=14;fontStyle=1;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;stroke=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;spacingTop=5;dashed=0;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="270" width="1140" height="570" as="geometry"/>
+                </mxCell>
+                <mxCell id="route53" value="Route 53" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.route_53" parent="1" vertex="1">
+                    <mxGeometry x="606" y="190" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-users-r53" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.5;exitY=1;entryX=0.5;entryY=0;" parent="1" source="users" target="route53" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="frontend-group" value="Frontend" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_region;stroke=#00A4A6;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;spacingTop=5;dashed=1;fontColor=#00A4A6;" parent="1" vertex="1">
+                    <mxGeometry x="106" y="310" width="380" height="310" as="geometry"/>
+                </mxCell>
+                <mxCell id="cloudfront" value="CloudFront" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudfront" parent="1" vertex="1">
+                    <mxGeometry x="266" y="340" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3-site" value="S3" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3" parent="1" vertex="1">
+                    <mxGeometry x="266" y="490" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-r53-cf" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0;exitY=1;entryX=0.5;entryY=0;" parent="1" source="route53" target="cloudfront" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-cf-s3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.5;exitY=1;entryX=0.5;entryY=0;" parent="1" source="cloudfront" target="s3-site" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="backend-group" value="Backend" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_region;stroke=#E7157B;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;spacingTop=5;dashed=1;fontColor=#E7157B;" parent="1" vertex="1">
+                    <mxGeometry x="550" y="310" width="310" height="310" as="geometry"/>
+                </mxCell>
+                <mxCell id="apigw" value="API Gateway V2" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.api_gateway" parent="1" vertex="1">
+                    <mxGeometry x="681" y="370" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="lambda" value="Lambda" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda" parent="1" vertex="1">
+                    <mxGeometry x="681" y="490" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-r53-apigw" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=1;exitY=1;entryX=0.5;entryY=0;" parent="1" source="route53" target="apigw" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-apigw-lambda" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.5;exitY=1;entryX=0.5;entryY=0;" parent="1" source="apigw" target="lambda" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3-icon" value="S3" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3" parent="1" vertex="1">
+                    <mxGeometry x="486" y="700" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="ses" value="SES" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#DD344C;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.simple_email_service" parent="1" vertex="1">
+                    <mxGeometry x="646" y="700" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-lambda-s3icon" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;fontSize=9;fontColor=#666666;labelBackgroundColor=#FFFFFF;" parent="1" source="lambda" target="s3-icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-lambda-ses" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;fontSize=9;fontColor=#666666;labelBackgroundColor=#FFFFFF;" parent="1" source="lambda" target="ses" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="ext-group" value="External Services" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_corporate_data_center;stroke=#147EBA;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;spacingTop=5;dashed=1;fontColor=#147EBA;" parent="1" vertex="1">
+                    <mxGeometry x="1220" y="290" width="230" height="380" as="geometry"/>
+                </mxCell>
+                <mxCell id="neon" value="Neon PostgreSQL" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;fontStyle=0;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="1295" y="340" width="90" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="gemini" value="Gemini API" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;fontStyle=0;size=15;" parent="1" vertex="1">
+                    <mxGeometry x="1275" y="590" width="130" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-lambda-neon" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;fontSize=9;fontColor=#666666;labelBackgroundColor=#FFFFFF;" parent="1" source="lambda" target="neon" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1340" y="514"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="e-lambda-gemini" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;fontSize=9;fontColor=#666666;labelBackgroundColor=#FFFFFF;" parent="1" source="lambda" target="gemini" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="secrets" value="SSM Parameter Store" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.parameter_store" parent="1" vertex="1">
+                    <mxGeometry x="976" y="670" width="48" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="e-secrets-lambda" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;dashed=1;dashPattern=8 8;strokeColor=#999999;fontSize=9;fontColor=#999999;labelBackgroundColor=#FFFFFF;" parent="1" source="secrets" target="lambda" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="920" y="700"/>
+                            <mxPoint x="920" y="514"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- draw.io 形式でインフラ構成図を `docs/infrastructure.drawio` に追加
- AWS サービス (Route 53, CloudFront, S3, API Gateway V2, Lambda, SES, SSM Parameter Store) と外部サービス (Neon PostgreSQL, Gemini API) の構成を図示
- AWS 公式アイコン (`mxgraph.aws4`) を使用

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)