### PR TITLE
fix: サイドバーとヘッダーをビューポートに固定する

### DIFF
--- a/apps/web/src/components/app-layout.tsx
+++ b/apps/web/src/components/app-layout.tsx
@@ -118,8 +118,8 @@ export function AppLayout() {
           </SidebarMenu>
         </SidebarFooter>
       </Sidebar>
-      <SidebarInset>
-        <header className="flex h-12 items-center gap-2 border-b px-4">
+      <SidebarInset className="max-h-svh overflow-hidden">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger />
           <Separator orientation="vertical" className="mr-2 h-4" />
           <span className="text-sm font-medium text-muted-foreground">
@@ -134,7 +134,7 @@ export function AppLayout() {
                 )?.label}
           </span>
         </header>
-        <div className="flex flex-1 flex-col p-4">
+        <div className="flex min-h-0 flex-1 flex-col overflow-auto p-4">
           <Outlet />
         </div>
       </SidebarInset>

--- a/apps/web/src/features/admin/admin-layout.tsx
+++ b/apps/web/src/features/admin/admin-layout.tsx
@@ -27,7 +27,7 @@ export function AdminLayout() {
   };
 
   return (
-    <div className="flex min-h-svh">
+    <div className="flex h-svh">
       <aside className="flex w-56 flex-col border-r bg-background">
         <div className="flex items-center gap-2 px-4 py-4">
           <Shield className="size-5 text-primary" />
@@ -70,7 +70,7 @@ export function AdminLayout() {
           </button>
         </div>
       </aside>
-      <main className="flex-1 overflow-auto bg-muted/40 p-6">
+      <main className="min-h-0 flex-1 overflow-auto bg-muted/40 p-6">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary

- サイドバーとヘッダーをビューポートに固定し、コンテンツエリアのみスクロールするように修正
- AppLayout: `SidebarInset` に `max-h-svh overflow-hidden`、ヘッダーに `shrink-0`、コンテンツに `min-h-0 overflow-auto` を追加
- AdminLayout: 親要素を `h-svh` に変更し、`<main>` に `min-h-0` を追加

## Test plan

- [ ] コンテンツが長いページ（管理画面のユーザー一覧等）でサイドバーがビューポートに固定されていることを確認
- [ ] コンテンツエリアのみスクロールし、ヘッダーが上部に固定されていることを確認
- [ ] モバイル表示でサイドバーの Sheet 動作に影響がないことを確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)