### PR TITLE
fix: サインイン/サインアップ時にメール登録状態を事前チェック

### DIFF
--- a/apps/api/src/application/user/check-email-registered.ts
+++ b/apps/api/src/application/user/check-email-registered.ts
@@ -1,0 +1,15 @@
+import type { UserQueryService } from "../../domain/user/query-service/user-query-service.ts";
+import type { UnitOfWork } from "../unit-of-work.ts";
+
+export class CheckEmailRegistered {
+  constructor(
+    private uow: UnitOfWork,
+    private userQueryService: UserQueryService,
+  ) {}
+
+  async execute(email: string): Promise<boolean> {
+    return this.uow.run(async () => {
+      return await this.userQueryService.isEmailRegistered(email);
+    });
+  }
+}

--- a/apps/api/src/composition-root.ts
+++ b/apps/api/src/composition-root.ts
@@ -27,6 +27,7 @@ import { DrizzleQuestionProposalRepository } from "./infrastructure/question-pro
 import { DrizzleQuestionProposalProjectionQueryService } from "./infrastructure/question-proposal/drizzle-question-proposal-projection-query-service.ts";
 import { DrizzleUserQueryService } from "./infrastructure/user/drizzle-user-query-service.ts";
 import { CheckUsernameAvailability } from "./application/user/check-username-availability.ts";
+import { CheckEmailRegistered } from "./application/user/check-email-registered.ts";
 import { ListUsers } from "./application/user/list-users.ts";
 import { GetUser } from "./application/user/get-user.ts";
 import { CategoryNameDuplicateChecker } from "./domain/category/service/category-name-duplicate-checker.ts";
@@ -179,6 +180,10 @@ const checkUsernameAvailability = new CheckUsernameAvailability(
   unitOfWork,
   userQueryService,
 );
+const checkEmailRegistered = new CheckEmailRegistered(
+  unitOfWork,
+  userQueryService,
+);
 
 const listUsers = new ListUsers(unitOfWork, userQueryService);
 const getUser = new GetUser(unitOfWork, userQueryService);
@@ -202,6 +207,7 @@ const getCategoryScores = new GetCategoryScores(
 
 export const dependencies = {
   checkUsernameAvailability,
+  checkEmailRegistered,
   listUsers,
   getUser,
   uploadIcon,

--- a/apps/api/src/domain/user/query-service/user-query-service.ts
+++ b/apps/api/src/domain/user/query-service/user-query-service.ts
@@ -16,6 +16,7 @@ export type ListUsersResult = {
 
 export interface UserQueryService {
   isUsernameAvailable(username: string): Promise<boolean>;
+  isEmailRegistered(email: string): Promise<boolean>;
   findById(userId: string): Promise<UserListItemDto | null>;
   listUsers(
     search: string | undefined,

--- a/apps/api/src/infrastructure/user/drizzle-user-query-service.ts
+++ b/apps/api/src/infrastructure/user/drizzle-user-query-service.ts
@@ -68,6 +68,16 @@ export class DrizzleUserQueryService implements UserQueryService {
     return rows.length === 0;
   }
 
+  async isEmailRegistered(email: string): Promise<boolean> {
+    const tx = getCurrentTransaction();
+    const rows = await tx
+      .select({ id: user.id })
+      .from(user)
+      .where(eq(user.email, email))
+      .limit(1);
+    return rows.length > 0;
+  }
+
   async findById(userId: string): Promise<UserListItemDto | null> {
     const tx = getCurrentTransaction();
     const lastLogin = createLastLoginSubquery(tx);

--- a/apps/api/src/presentation/routes/user/user.route.ts
+++ b/apps/api/src/presentation/routes/user/user.route.ts
@@ -28,6 +28,30 @@ const checkUsernameRoute = createRoute({
   },
 });
 
+const checkEmailRoute = createRoute({
+  method: "get",
+  path: "/check-email",
+  tags: ["User"],
+  summary: "メールアドレスの登録有無チェック",
+  request: {
+    query: z.object({
+      email: z.string().email(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "チェック結果",
+      content: {
+        "application/json": {
+          schema: z
+            .object({ registered: z.boolean() })
+            .openapi("CheckEmailResponse"),
+        },
+      },
+    },
+  },
+});
+
 const uploadIconRoute = createRoute({
   method: "post",
   path: "/icon",
@@ -85,6 +109,11 @@ export const createUserRoute = (deps: Dependencies) =>
       const { username } = c.req.valid("query");
       const available = await deps.checkUsernameAvailability.execute(username);
       return c.json({ available });
+    })
+    .openapi(checkEmailRoute, async (c) => {
+      const { email } = c.req.valid("query");
+      const registered = await deps.checkEmailRegistered.execute(email);
+      return c.json({ registered });
     })
     .openapi(uploadIconRoute, async (c) => {
       const body = await c.req.parseBody();

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/auth-client";
+import { client } from "@/client";
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -22,6 +23,22 @@ export function LoginPage() {
     e.preventDefault();
     setError("");
     setIsLoading(true);
+
+    try {
+      const res = await client.api.user["check-email"].$get({
+        query: { email },
+      });
+      const { registered } = await res.json();
+      if (!registered) {
+        setIsLoading(false);
+        setError("アカウントが見つかりません。");
+        return;
+      }
+    } catch {
+      setIsLoading(false);
+      setError("メールアドレスの確認に失敗しました。");
+      return;
+    }
 
     const { error } = await authClient.emailOtp.sendVerificationOtp({
       email,

--- a/apps/web/src/features/auth/signup-page.tsx
+++ b/apps/web/src/features/auth/signup-page.tsx
@@ -52,6 +52,22 @@ export function SignupPage() {
       return;
     }
 
+    try {
+      const res = await client.api.user["check-email"].$get({
+        query: { email },
+      });
+      const { registered } = await res.json();
+      if (registered) {
+        setIsLoading(false);
+        setError("このメールアドレスは既に登録されています。");
+        return;
+      }
+    } catch {
+      setIsLoading(false);
+      setError("メールアドレスの確認に失敗しました。");
+      return;
+    }
+
     const { error } = await authClient.emailOtp.sendVerificationOtp({
       email,
       type: "sign-in",


### PR DESCRIPTION
## Summary

- `/api/user/check-email` エンドポイントを追加し、メールアドレスの登録有無を返す
- ログイン画面: OTP送信前に未登録メールなら「アカウントが見つかりません」エラーを表示
- サインアップ画面: OTP送信前に登録済みメールなら「このメールアドレスは既に登録されています」エラーを表示

Closes #59

## Test plan

- [ ] ログイン画面で登録済みメール → OTP送信・遷移されること
- [ ] ログイン画面で未登録メール → 「アカウントが見つかりません」エラー表示
- [ ] サインアップ画面で未登録メール＋未使用ユーザー名 → OTP送信・遷移されること
- [ ] サインアップ画面で登録済みメール → 「このメールアドレスは既に登録されています」エラー表示
- [ ] サインアップ画面で使用済みユーザー名 → 既存の「このユーザー名は既に使われています」エラー表示（リグレッション確認）
- [ ] OTP検証後にログイン/アカウント作成が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)