### PR TITLE
refactor: admin/user の出題案ページの重複コードを共通化

### DIFF
--- a/apps/web/src/features/admin/proposals/proposal-content-cards.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-content-cards.tsx
@@ -1,0 +1,84 @@
+import { Check } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type ProposalContentCardsProps = {
+  text: string;
+  choices: string[];
+  correctIndexes: number[];
+  explanation: string;
+  rejectReason?: string | null;
+};
+
+export function ProposalContentCards({
+  text,
+  choices,
+  correctIndexes,
+  explanation,
+  rejectReason,
+}: ProposalContentCardsProps) {
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">問題文</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="whitespace-pre-wrap">{text}</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">選択肢</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2">
+            {choices.map((choice, i) => {
+              const isCorrect = correctIndexes.includes(i);
+              return (
+                <li
+                  key={i}
+                  className={`rounded-md border px-4 py-2 text-sm ${
+                    isCorrect
+                      ? "border-green-500 bg-green-50 dark:bg-green-950"
+                      : ""
+                  }`}
+                >
+                  <span className="mr-2 font-mono text-muted-foreground">
+                    {String.fromCharCode(65 + i)}.
+                  </span>
+                  {choice}
+                  {isCorrect && (
+                    <Check className="ml-2 inline size-4 text-green-600" />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">解説</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="whitespace-pre-wrap">{explanation}</p>
+        </CardContent>
+      </Card>
+
+      {rejectReason && (
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="text-base text-destructive">
+              却下理由
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="whitespace-pre-wrap">{rejectReason}</p>
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/admin/proposals/proposal-detail-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-detail-page.tsx
@@ -153,11 +153,13 @@ export function ProposalDetailPage() {
     <>
       <ProposalDetailView
         proposal={proposal}
+        backTo="/admin/proposals"
         canEdit={canEdit}
         onEdit={() => setEditing(true)}
+        onSubmit={() => submitMutation.mutate()}
+        submitPending={submitMutation.isPending}
         onApprove={() => approveMutation.mutate()}
         onRejectClick={() => setRejectDialogOpen(true)}
-        onSubmit={() => submitMutation.mutate()}
         onWithdraw={() => {
           if (
             window.confirm(
@@ -168,7 +170,6 @@ export function ProposalDetailPage() {
           }
         }}
         approvePending={approveMutation.isPending}
-        submitPending={submitMutation.isPending}
         withdrawPending={withdrawMutation.isPending}
       />
       <RejectDialog

--- a/apps/web/src/features/admin/proposals/proposal-detail-view.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-detail-view.tsx
@@ -2,8 +2,8 @@ import { useNavigate } from "react-router-dom";
 import { ArrowLeft, Check, X, Pencil, Send, ArchiveX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { statusLabels, statusVariants, difficultyLabels } from "./constants";
+import { ProposalContentCards } from "./proposal-content-cards";
 
 type Proposal = {
   status: string;
@@ -18,39 +18,37 @@ type Proposal = {
 
 type ProposalDetailViewProps = {
   proposal: Proposal;
+  backTo: string;
   canEdit: boolean;
   onEdit: () => void;
-  onApprove: () => void;
-  onRejectClick: () => void;
   onSubmit: () => void;
-  onWithdraw: () => void;
-  approvePending: boolean;
   submitPending: boolean;
-  withdrawPending: boolean;
+  onApprove?: () => void;
+  onRejectClick?: () => void;
+  onWithdraw?: () => void;
+  approvePending?: boolean;
+  withdrawPending?: boolean;
 };
 
 export function ProposalDetailView({
   proposal,
+  backTo,
   canEdit,
   onEdit,
+  onSubmit,
+  submitPending,
   onApprove,
   onRejectClick,
-  onSubmit,
   onWithdraw,
   approvePending,
-  submitPending,
   withdrawPending,
 }: ProposalDetailViewProps) {
   const navigate = useNavigate();
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="space-y-6 px-2">
       <div className="flex items-center gap-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate("/admin/proposals")}
-        >
+        <Button variant="ghost" size="sm" onClick={() => navigate(backTo)}>
           <ArrowLeft className="size-4" />
           一覧へ戻る
         </Button>
@@ -58,7 +56,7 @@ export function ProposalDetailView({
 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h2 className="text-2xl font-bold tracking-tight">提案詳細</h2>
+          <h2 className="text-2xl font-bold tracking-tight">出題案詳細</h2>
           <Badge variant={statusVariants[proposal.status] ?? "outline"}>
             {statusLabels[proposal.status] ?? proposal.status}
           </Badge>
@@ -70,7 +68,7 @@ export function ProposalDetailView({
           )}
         </div>
         <div className="flex items-center gap-2">
-          {proposal.status === "reviewed" && (
+          {proposal.status === "reviewed" && onRejectClick && (
             <Button variant="destructive" onClick={onRejectClick}>
               <X className="size-4" />
               却下
@@ -85,16 +83,16 @@ export function ProposalDetailView({
           {proposal.status === "pending" && (
             <Button onClick={onSubmit} disabled={submitPending}>
               <Send className="size-4" />
-              {submitPending ? "申請中..." : "申請"}
+              {submitPending ? "申請中..." : "申請する"}
             </Button>
           )}
-          {proposal.status === "reviewed" && (
+          {proposal.status === "reviewed" && onApprove && (
             <Button onClick={onApprove} disabled={approvePending}>
               <Check className="size-4" />
               {approvePending ? "承認中..." : "承認"}
             </Button>
           )}
-          {proposal.status === "approved" && (
+          {proposal.status === "approved" && onWithdraw && (
             <Button
               variant="destructive"
               onClick={onWithdraw}
@@ -107,67 +105,13 @@ export function ProposalDetailView({
         </div>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">問題文</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="whitespace-pre-wrap">{proposal.text}</p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">選択肢</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2">
-            {proposal.choices.map((choice, i) => {
-              const isCorrect = proposal.correctIndexes.includes(i);
-              return (
-                <li
-                  key={i}
-                  className={`rounded-md border px-4 py-2 text-sm ${
-                    isCorrect
-                      ? "border-green-500 bg-green-50 dark:bg-green-950"
-                      : ""
-                  }`}
-                >
-                  <span className="mr-2 font-mono text-muted-foreground">
-                    {String.fromCharCode(65 + i)}.
-                  </span>
-                  {choice}
-                  {isCorrect && (
-                    <Check className="ml-2 inline size-4 text-green-600" />
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">解説</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="whitespace-pre-wrap">{proposal.explanation}</p>
-        </CardContent>
-      </Card>
-
-      {proposal.rejectReason && (
-        <Card className="border-destructive">
-          <CardHeader>
-            <CardTitle className="text-base text-destructive">
-              却下理由
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="whitespace-pre-wrap">{proposal.rejectReason}</p>
-          </CardContent>
-        </Card>
-      )}
+      <ProposalContentCards
+        text={proposal.text}
+        choices={proposal.choices}
+        correctIndexes={proposal.correctIndexes}
+        explanation={proposal.explanation}
+        rejectReason={proposal.rejectReason}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/admin/proposals/proposal-edit-form.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-edit-form.tsx
@@ -75,6 +75,10 @@ type ProposalEditFormProps = {
   onCancel: () => void;
   isPending: boolean;
   error?: string;
+  title?: string;
+  cancelLabel?: string;
+  submitLabel?: string;
+  showFooterCancel?: boolean;
 };
 
 export function ProposalEditForm({
@@ -83,6 +87,10 @@ export function ProposalEditForm({
   onCancel,
   isPending,
   error,
+  title = "提案を編集",
+  cancelLabel = "編集をキャンセル",
+  submitLabel = "保存",
+  showFooterCancel = true,
 }: ProposalEditFormProps) {
   const form = useForm<EditFormData>({
     resolver: zodResolver(editSchema),
@@ -128,15 +136,15 @@ export function ProposalEditForm({
   const correctIndexes = form.watch("correctIndexes");
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="space-y-6 px-2">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="sm" onClick={onCancel}>
           <ArrowLeft className="size-4" />
-          編集をキャンセル
+          {cancelLabel}
         </Button>
       </div>
 
-      <h2 className="text-2xl font-bold tracking-tight">提案を編集</h2>
+      <h2 className="text-2xl font-bold tracking-tight">{title}</h2>
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -324,11 +332,13 @@ export function ProposalEditForm({
           </Card>
 
           <div className="flex justify-end gap-3">
-            <Button type="button" variant="outline" onClick={onCancel}>
-              キャンセル
-            </Button>
+            {showFooterCancel && (
+              <Button type="button" variant="outline" onClick={onCancel}>
+                キャンセル
+              </Button>
+            )}
             <Button type="submit" disabled={isPending}>
-              {isPending ? "保存中..." : "保存"}
+              {isPending ? `${submitLabel}中...` : submitLabel}
             </Button>
           </div>
 

--- a/apps/web/src/features/admin/proposals/proposal-list-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-list-page.tsx
@@ -65,7 +65,7 @@ export function ProposalListPage() {
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 px-2">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold tracking-tight">出題案</h2>
         <div className="flex items-center gap-2">

--- a/apps/web/src/features/admin/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/admin/proposals/proposal-new-page.tsx
@@ -1,106 +1,13 @@
 import { useNavigate } from "react-router-dom";
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { useForm, useFieldArray } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { ArrowLeft, Plus, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { useMutation } from "@tanstack/react-query";
+import { ProposalEditForm, type EditFormData } from "./proposal-edit-form";
 import { client } from "@/client";
-
-const MAX_QUESTION_TEXT = 500;
-const MAX_EXPLANATION = 1000;
-const MIN_CHOICES = 4;
-const MAX_CHOICES = 8;
-
-const proposalSchema = z
-  .object({
-    questionText: z
-      .string()
-      .trim()
-      .min(1, "問題文を入力してください")
-      .max(MAX_QUESTION_TEXT, `${MAX_QUESTION_TEXT}文字以内で入力してください`),
-    difficulty: z.enum(["easy", "medium", "hard"], {
-      message: "難易度を選択してください",
-    }),
-    choices: z
-      .array(
-        z.object({
-          value: z.string().trim().min(1, "選択肢を入力してください"),
-        }),
-      )
-      .min(MIN_CHOICES, `選択肢は${MIN_CHOICES}つ以上必要です`)
-      .max(MAX_CHOICES, `選択肢は${MAX_CHOICES}つまでです`),
-    correctIndexes: z
-      .array(z.number().int())
-      .min(1, "正解を1つ以上選択してください"),
-    explanation: z
-      .string()
-      .trim()
-      .min(1, "解説を入力してください")
-      .max(MAX_EXPLANATION, `${MAX_EXPLANATION}文字以内で入力してください`),
-    categoryId: z.string().uuid("カテゴリを選択してください"),
-  })
-  .refine(
-    (data) =>
-      data.correctIndexes.every((i) => i >= 0 && i < data.choices.length),
-    {
-      message: "正解インデックスが選択肢の範囲外です",
-      path: ["correctIndexes"],
-    },
-  );
-
-type ProposalForm = z.infer<typeof proposalSchema>;
 
 export function ProposalNewPage() {
   const navigate = useNavigate();
 
-  const form = useForm<ProposalForm>({
-    resolver: zodResolver(proposalSchema),
-    defaultValues: {
-      questionText: "",
-      difficulty: "medium",
-      choices: [{ value: "" }, { value: "" }, { value: "" }, { value: "" }],
-      correctIndexes: [],
-      explanation: "",
-      categoryId: "",
-    },
-  });
-
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: "choices",
-  });
-
-  const { data: categories } = useQuery({
-    queryKey: ["categories"],
-    queryFn: async () => {
-      const res = await client.api.categories.$get();
-      if (!res.ok) throw new Error("Failed to fetch categories");
-      return res.json();
-    },
-  });
-
   const createMutation = useMutation({
-    mutationFn: async (data: ProposalForm) => {
+    mutationFn: async (data: EditFormData) => {
       const res = await client.api["question-proposals"].$post({
         json: {
           questionText: data.questionText,
@@ -119,246 +26,24 @@ export function ProposalNewPage() {
     },
   });
 
-  const toggleCorrect = (index: number) => {
-    const current = form.getValues("correctIndexes");
-    const next = current.includes(index)
-      ? current.filter((i) => i !== index)
-      : [...current, index];
-    form.setValue("correctIndexes", next, { shouldValidate: true });
-  };
-
-  const handleRemoveChoice = (index: number) => {
-    const current = form.getValues("correctIndexes");
-    form.setValue(
-      "correctIndexes",
-      current
-        .filter((ci) => ci !== index)
-        .map((ci) => (ci > index ? ci - 1 : ci)),
-      { shouldValidate: true },
-    );
-    remove(index);
-  };
-
-  const questionText = form.watch("questionText");
-  const explanation = form.watch("explanation");
-  const correctIndexes = form.watch("correctIndexes");
-
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
-      <div className="flex items-center gap-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate("/admin/proposals")}
-        >
-          <ArrowLeft className="size-4" />
-          一覧へ戻る
-        </Button>
-      </div>
-
-      <h2 className="text-2xl font-bold tracking-tight">出題案を作成</h2>
-
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit((data) => createMutation.mutate(data))}
-          className="space-y-6"
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">基本情報</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <FormField
-                control={form.control}
-                name="questionText"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>問題文</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="問題文を入力"
-                        rows={4}
-                        maxLength={MAX_QUESTION_TEXT}
-                        {...field}
-                      />
-                    </FormControl>
-                    <div className="flex items-center justify-between">
-                      <FormMessage />
-                      <p className="ml-auto text-xs text-muted-foreground">
-                        {questionText.length} / {MAX_QUESTION_TEXT}
-                      </p>
-                    </div>
-                  </FormItem>
-                )}
-              />
-
-              <div className="grid grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="difficulty"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>難易度</FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={field.onChange}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="easy">簡単</SelectItem>
-                          <SelectItem value="medium">普通</SelectItem>
-                          <SelectItem value="hard">難しい</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="categoryId"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>カテゴリ</FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={field.onChange}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="選択してください" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {categories?.map((cat) => (
-                            <SelectItem key={cat.id} value={cat.id}>
-                              {cat.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">選択肢</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {fields.map((field, i) => (
-                <div key={field.id} className="flex items-center gap-2">
-                  <Checkbox
-                    checked={correctIndexes.includes(i)}
-                    onCheckedChange={() => toggleCorrect(i)}
-                  />
-                  <span className="w-6 font-mono text-sm text-muted-foreground">
-                    {String.fromCharCode(65 + i)}.
-                  </span>
-                  <FormField
-                    control={form.control}
-                    name={`choices.${i}.value`}
-                    render={({ field: choiceField }) => (
-                      <FormItem className="flex-1">
-                        <FormControl>
-                          <Input
-                            placeholder={`選択肢 ${String.fromCharCode(65 + i)}`}
-                            {...choiceField}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  {fields.length > MIN_CHOICES && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleRemoveChoice(i)}
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  )}
-                </div>
-              ))}
-              {fields.length < MAX_CHOICES && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => append({ value: "" })}
-                >
-                  <Plus className="size-4" />
-                  選択肢を追加
-                </Button>
-              )}
-              <FormField
-                control={form.control}
-                name="correctIndexes"
-                render={() => (
-                  <FormItem>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <p className="text-xs text-muted-foreground">
-                チェックボックスで正解の選択肢を選択してください（複数選択可）
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">解説</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <FormField
-                control={form.control}
-                name="explanation"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <Textarea
-                        placeholder="解説を入力"
-                        rows={4}
-                        maxLength={MAX_EXPLANATION}
-                        {...field}
-                      />
-                    </FormControl>
-                    <div className="flex items-center justify-between">
-                      <FormMessage />
-                      <p className="ml-auto text-xs text-muted-foreground">
-                        {explanation.length} / {MAX_EXPLANATION}
-                      </p>
-                    </div>
-                  </FormItem>
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <div className="flex justify-end">
-            <Button type="submit" disabled={createMutation.isPending}>
-              {createMutation.isPending ? "作成中..." : "提案を作成"}
-            </Button>
-          </div>
-
-          {createMutation.isError && (
-            <p className="text-sm text-destructive">
-              エラー: {createMutation.error.message}
-            </p>
-          )}
-        </form>
-      </Form>
-    </div>
+    <ProposalEditForm
+      defaultValues={{
+        questionText: "",
+        difficulty: "medium",
+        choices: [{ value: "" }, { value: "" }, { value: "" }, { value: "" }],
+        correctIndexes: [],
+        explanation: "",
+        categoryId: "",
+      }}
+      onSubmit={(data) => createMutation.mutate(data)}
+      onCancel={() => navigate("/admin/proposals")}
+      isPending={createMutation.isPending}
+      error={createMutation.error?.message}
+      title="出題案を作成"
+      cancelLabel="一覧へ戻る"
+      submitLabel="出題案を作成"
+      showFooterCancel={false}
+    />
   );
 }

--- a/apps/web/src/features/proposals/proposal-detail-page.tsx
+++ b/apps/web/src/features/proposals/proposal-detail-page.tsx
@@ -1,24 +1,15 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Pencil, Send, Check } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { client } from "@/client";
 import {
   ProposalEditForm,
   type EditFormData,
 } from "../admin/proposals/proposal-edit-form";
-import {
-  statusLabels,
-  statusVariants,
-  difficultyLabels,
-} from "../admin/proposals/constants";
+import { ProposalDetailView } from "../admin/proposals/proposal-detail-view";
 
 export function UserProposalDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
 
@@ -99,108 +90,13 @@ export function UserProposalDetailPage() {
   const canEdit = ["pending", "rejected"].includes(proposal.status);
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
-      <div className="flex items-center gap-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate("/proposals")}
-        >
-          <ArrowLeft className="size-4" />
-          一覧へ戻る
-        </Button>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h2 className="text-2xl font-bold tracking-tight">出題案詳細</h2>
-          <Badge variant={statusVariants[proposal.status] ?? "outline"}>
-            {statusLabels[proposal.status] ?? proposal.status}
-          </Badge>
-          <Badge variant="secondary">
-            {difficultyLabels[proposal.difficulty] ?? proposal.difficulty}
-          </Badge>
-        </div>
-        <div className="flex items-center gap-2">
-          {canEdit && (
-            <Button variant="outline" onClick={() => setEditing(true)}>
-              <Pencil className="size-4" />
-              編集
-            </Button>
-          )}
-          {proposal.status === "pending" && (
-            <Button
-              onClick={() => submitMutation.mutate()}
-              disabled={submitMutation.isPending}
-            >
-              <Send className="size-4" />
-              {submitMutation.isPending ? "申請中..." : "申請する"}
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">問題文</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="whitespace-pre-wrap">{proposal.text}</p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">選択肢</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2">
-            {proposal.choices.map((choice, i) => {
-              const isCorrect = proposal.correctIndexes.includes(i);
-              return (
-                <li
-                  key={i}
-                  className={`rounded-md border px-4 py-2 text-sm ${
-                    isCorrect
-                      ? "border-green-500 bg-green-50 dark:bg-green-950"
-                      : ""
-                  }`}
-                >
-                  <span className="mr-2 font-mono text-muted-foreground">
-                    {String.fromCharCode(65 + i)}.
-                  </span>
-                  {choice}
-                  {isCorrect && (
-                    <Check className="ml-2 inline size-4 text-green-600" />
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">解説</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="whitespace-pre-wrap">{proposal.explanation}</p>
-        </CardContent>
-      </Card>
-
-      {proposal.rejectReason && (
-        <Card className="border-destructive">
-          <CardHeader>
-            <CardTitle className="text-base text-destructive">
-              却下理由
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="whitespace-pre-wrap">{proposal.rejectReason}</p>
-          </CardContent>
-        </Card>
-      )}
-    </div>
+    <ProposalDetailView
+      proposal={proposal}
+      backTo="/proposals"
+      canEdit={canEdit}
+      onEdit={() => setEditing(true)}
+      onSubmit={() => submitMutation.mutate()}
+      submitPending={submitMutation.isPending}
+    />
   );
 }

--- a/apps/web/src/features/proposals/proposal-list-page.tsx
+++ b/apps/web/src/features/proposals/proposal-list-page.tsx
@@ -56,7 +56,7 @@ export function UserProposalListPage() {
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 px-2">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold tracking-tight">出題案</h2>
         <Button onClick={() => navigate("/proposals/new")}>

--- a/apps/web/src/features/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/proposals/proposal-new-page.tsx
@@ -43,6 +43,10 @@ export function UserProposalNewPage() {
       onCancel={() => navigate("/proposals")}
       isPending={createMutation.isPending}
       error={createMutation.error?.message}
+      title="出題案を作成"
+      cancelLabel="一覧へ戻る"
+      submitLabel="出題案を作成"
+      showFooterCancel={false}
     />
   );
 }


### PR DESCRIPTION
## Summary
- admin の `ProposalNewPage` を `ProposalEditForm` 利用に書き換え (~300行削減)
- 詳細表示の Card 部分を `ProposalContentCards` として共通コンポーネントに抽出
- user の詳細ページが `ProposalDetailView` を共有するよう変更 (admin専用アクションはオプショナル props)
- `ProposalEditForm` に `title`/`cancelLabel`/`submitLabel`/`showFooterCancel` props を追加し、新規作成と編集で文言を統一
- 全ページに `px-2` パディングを追加、`max-w` 制約を削除

## Test plan
- [ ] `/proposals/new` で出題案を新規作成できること
- [ ] `/admin/proposals/new` で出題案を新規作成できること
- [ ] `/proposals/:id` で詳細表示・編集・申請ができること
- [ ] `/admin/proposals/:id` で詳細表示・編集・承認・却下・取り下げができること
- [ ] 一覧ページと詳細ページの横幅が統一されていること
- [ ] 新規作成ページにフッターのキャンセルボタンが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)