### PR TITLE
feat: プライバシーポリシー・利用規約ページの追加

### DIFF
--- a/apps/web/src/components/app-layout.tsx
+++ b/apps/web/src/components/app-layout.tsx
@@ -25,6 +25,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
+import { LegalFooter } from "@/components/legal-footer";
 
 const navItems = [
   { to: "/", label: "ドリル", icon: BookOpen },
@@ -123,6 +124,7 @@ export function AppLayout() {
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
+          <LegalFooter className="mt-2 pb-1" />
         </SidebarFooter>
       </Sidebar>
       <SidebarInset className="max-h-svh overflow-hidden">

--- a/apps/web/src/components/legal-footer.tsx
+++ b/apps/web/src/components/legal-footer.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+
+export function LegalFooter({ className }: { className?: string }) {
+  return (
+    <div
+      className={`flex items-center justify-center gap-3 text-xs text-muted-foreground ${className ?? ""}`}
+    >
+      <Link
+        to="/privacy"
+        className="underline underline-offset-4 hover:text-foreground"
+      >
+        プライバシーポリシー
+      </Link>
+      <span>|</span>
+      <Link
+        to="/terms"
+        className="underline underline-offset-4 hover:text-foreground"
+      >
+        利用規約
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/auth-client";
 import { client } from "@/client";
+import { LegalFooter } from "@/components/legal-footer";
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -54,7 +55,7 @@ export function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-svh items-center justify-center bg-muted/40 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted/40 px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto flex items-center gap-2">
@@ -108,6 +109,7 @@ export function LoginPage() {
           </p>
         </CardContent>
       </Card>
+      <LegalFooter className="mt-4" />
     </div>
   );
 }

--- a/apps/web/src/features/auth/signup-page.tsx
+++ b/apps/web/src/features/auth/signup-page.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/auth-client";
 import { client } from "@/client";
+import { LegalFooter } from "@/components/legal-footer";
 
 export function SignupPage() {
   const navigate = useNavigate();
@@ -77,7 +78,7 @@ export function SignupPage() {
   };
 
   return (
-    <div className="flex min-h-svh items-center justify-center bg-muted/40 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted/40 px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto flex items-center gap-2">
@@ -168,6 +169,7 @@ export function SignupPage() {
           </p>
         </CardContent>
       </Card>
+      <LegalFooter className="mt-4" />
     </div>
   );
 }

--- a/apps/web/src/features/auth/verify-otp-page.tsx
+++ b/apps/web/src/features/auth/verify-otp-page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/auth-client";
+import { LegalFooter } from "@/components/legal-footer";
 
 export function VerifyOtpPage() {
   const navigate = useNavigate();
@@ -68,7 +69,7 @@ export function VerifyOtpPage() {
   };
 
   return (
-    <div className="flex min-h-svh items-center justify-center bg-muted/40 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted/40 px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto flex items-center gap-2">
@@ -125,6 +126,7 @@ export function VerifyOtpPage() {
           </form>
         </CardContent>
       </Card>
+      <LegalFooter className="mt-4" />
     </div>
   );
 }

--- a/apps/web/src/features/legal/privacy-page.tsx
+++ b/apps/web/src/features/legal/privacy-page.tsx
@@ -1,0 +1,111 @@
+import { Link } from "react-router-dom";
+import { FlaskConical, ArrowLeft } from "lucide-react";
+
+export function PrivacyPage() {
+  return (
+    <div className="min-h-svh bg-muted/40">
+      <header className="sticky top-0 z-10 flex items-center border-b bg-background px-6 py-4">
+        <Link
+          to="/"
+          className="flex items-center gap-2 text-lg font-semibold tracking-tight"
+        >
+          <FlaskConical className="size-5 text-primary" />
+          Chem Drill
+        </Link>
+      </header>
+
+      <main className="mx-auto w-full max-w-2xl px-4 py-8">
+        <Link
+          to="/"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          トップに戻る
+        </Link>
+
+        <article className="prose prose-sm dark:prose-invert max-w-none space-y-6">
+          <h1 className="text-2xl font-bold">プライバシーポリシー</h1>
+
+          <p>
+            Chem Drill（以下「本サービス」）は、ユーザーのプライバシーを尊重し、
+            個人情報の保護に努めています。本プライバシーポリシーは、
+            本サービスにおける個人情報の取り扱いについて説明するものです。
+          </p>
+
+          <h2 className="text-xl font-semibold">1. 収集する情報</h2>
+          <p>本サービスでは、以下の情報を収集します。</p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>メールアドレス（ユーザー認証のため）</li>
+            <li>ユーザー名・表示名（アカウント識別のため）</li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">2. 情報の利用目的</h2>
+          <p>収集した情報は、以下の目的でのみ使用します。</p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>ユーザー認証（ワンタイムパスワード（OTP）の送信）</li>
+            <li>アカウントの管理・識別</li>
+          </ul>
+          <p>
+            マーケティング目的でのメール送信や、ニュースレターの配信は一切行いません。
+          </p>
+
+          <h2 className="text-xl font-semibold">3. 第三者への提供</h2>
+          <p>
+            ユーザーの個人情報は、原則として第三者に提供しません。
+            ただし、以下の場合を除きます。
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>メールの送信に外部サービスを利用する場合があります</li>
+            <li>法令に基づく開示要求があった場合</li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">4. データの保持期間</h2>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              ワンタイムパスワード（OTP）は発行から5分間のみ有効で、
+              期限経過後に無効化されます
+            </li>
+            <li>
+              アカウント情報は、ユーザーがアカウントを削除するまで保持されます
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">5. セキュリティ</h2>
+          <p>
+            本サービスでは、ユーザーの個人情報を保護するために、
+            適切な技術的・組織的な安全対策を講じています。通信は SSL/TLS
+            により暗号化されています。
+          </p>
+
+          <h2 className="text-xl font-semibold">6. Cookie の使用</h2>
+          <p>
+            本サービスでは、ユーザー認証セッションの管理のために Cookie
+            を使用しています。これは本サービスの機能に
+            必要なものであり、トラッキング目的では使用しません。
+          </p>
+
+          <h2 className="text-xl font-semibold">
+            7. プライバシーポリシーの変更
+          </h2>
+          <p>
+            本ポリシーは、必要に応じて変更されることがあります。
+            重要な変更がある場合は、本サービス上でお知らせします。
+          </p>
+
+          <h2 className="text-xl font-semibold">8. お問い合わせ</h2>
+          <p>
+            プライバシーに関するお問い合わせは、以下のメールアドレスまでご連絡ください。
+          </p>
+          <p>
+            <a
+              href="mailto:support@chem-drill.com"
+              className="text-primary underline underline-offset-4"
+            >
+              support@chem-drill.com
+            </a>
+          </p>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/features/legal/terms-page.tsx
+++ b/apps/web/src/features/legal/terms-page.tsx
@@ -1,0 +1,108 @@
+import { Link } from "react-router-dom";
+import { FlaskConical, ArrowLeft } from "lucide-react";
+
+export function TermsPage() {
+  return (
+    <div className="min-h-svh bg-muted/40">
+      <header className="sticky top-0 z-10 flex items-center border-b bg-background px-6 py-4">
+        <Link
+          to="/"
+          className="flex items-center gap-2 text-lg font-semibold tracking-tight"
+        >
+          <FlaskConical className="size-5 text-primary" />
+          Chem Drill
+        </Link>
+      </header>
+
+      <main className="mx-auto w-full max-w-2xl px-4 py-8">
+        <Link
+          to="/"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          トップに戻る
+        </Link>
+
+        <article className="prose prose-sm dark:prose-invert max-w-none space-y-6">
+          <h1 className="text-2xl font-bold">利用規約</h1>
+
+          <p>
+            この利用規約（以下「本規約」）は、Chem Drill（以下「本サービス」）の
+            利用条件を定めるものです。本サービスをご利用いただく前に、
+            本規約をよくお読みください。
+          </p>
+
+          <h2 className="text-xl font-semibold">1. サービスの概要</h2>
+          <p>
+            本サービスは、化学に関する学習を支援するためのクイズプラットフォームです。
+            ユーザーは、化学物質に関する問題に取り組むことができます。
+          </p>
+
+          <h2 className="text-xl font-semibold">2. アカウント</h2>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>本サービスの利用にはアカウント登録が必要です</li>
+            <li>
+              ユーザーは正確な情報を提供し、アカウントの安全を
+              管理する責任を負います
+            </li>
+            <li>1人のユーザーが複数のアカウントを作成することは禁止します</li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">3. 禁止事項</h2>
+          <p>以下の行為を禁止します。</p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>本サービスの不正利用・悪用</li>
+            <li>他のユーザーへの嫌がらせや迷惑行為</li>
+            <li>本サービスのセキュリティを侵害する行為</li>
+            <li>自動化されたアクセスやスクレイピング</li>
+            <li>法令に違反する行為</li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">4. 知的財産権</h2>
+          <p>
+            本サービスのコンテンツ（問題、解説、デザイン等）に関する
+            知的財産権は、本サービスの運営者に帰属します。
+          </p>
+
+          <h2 className="text-xl font-semibold">5. 免責事項</h2>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>本サービスは「現状のまま」提供されます</li>
+            <li>
+              問題の正確性について最善を尽くしますが、
+              誤りが含まれる可能性があります
+            </li>
+            <li>
+              本サービスの利用により生じた損害について、
+              運営者は法令上許容される範囲で責任を負いません
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold">6. サービスの変更・停止</h2>
+          <p>
+            運営者は、事前の通知なく本サービスの内容を変更、
+            または一時的もしくは永久に停止する場合があります。
+          </p>
+
+          <h2 className="text-xl font-semibold">7. 規約の変更</h2>
+          <p>
+            本規約は、必要に応じて変更されることがあります。
+            変更後の規約は、本サービス上に掲載した時点で効力を生じるものとします。
+          </p>
+
+          <h2 className="text-xl font-semibold">8. お問い合わせ</h2>
+          <p>
+            本規約に関するお問い合わせは、以下のメールアドレスまでご連絡ください。
+          </p>
+          <p>
+            <a
+              href="mailto:support@chem-drill.com"
+              className="text-primary underline underline-offset-4"
+            >
+              support@chem-drill.com
+            </a>
+          </p>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/features/trial/trial-page.tsx
+++ b/apps/web/src/features/trial/trial-page.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { FlaskConical, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SessionContainer } from "@/features/question/session-container";
+import { LegalFooter } from "@/components/legal-footer";
 import { TRIAL_QUESTIONS } from "./trial-questions";
 
 export function TrialPage() {
@@ -37,6 +38,10 @@ export function TrialPage() {
           }
         />
       </main>
+
+      <footer className="border-t bg-background px-6 py-4">
+        <LegalFooter />
+      </footer>
     </div>
   );
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,6 +26,8 @@ import { AccountPage } from "./features/account/account-page";
 import { UserProposalListPage } from "./features/proposals/proposal-list-page";
 import { UserProposalNewPage } from "./features/proposals/proposal-new-page";
 import { UserProposalDetailPage } from "./features/proposals/proposal-detail-page";
+import { PrivacyPage } from "./features/legal/privacy-page";
+import { TermsPage } from "./features/legal/terms-page";
 import "./index.css";
 
 function Root() {
@@ -39,6 +41,8 @@ function Root() {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/verify-otp" element={<VerifyOtpPage />} />
           <Route path="/trial" element={<TrialPage />} />
+          <Route path="/privacy" element={<PrivacyPage />} />
+          <Route path="/terms" element={<TermsPage />} />
           <Route element={<ProtectedRoute />}>
             <Route element={<AppLayout />}>
               <Route path="/" element={<CategorySelectPage />} />


### PR DESCRIPTION
## Summary
- AWS SES 送信制限解除の再申請に向けて、プライバシーポリシー (`/privacy`) と利用規約 (`/terms`) ページを新規作成
- ログイン・新規登録・OTP検証・トライアル・サイドバーの全ページにフッターリンクを設置
- お問い合わせ先として `support@chem-drill.com` を記載（ImprovMX で転送設定済み）

## Test plan
- [ ] `/privacy` にアクセスしてプライバシーポリシーが表示されること
- [ ] `/terms` にアクセスして利用規約が表示されること
- [ ] 両ページでヘッダーがスクロール時に固定されること
- [ ] ログイン・新規登録・OTP検証ページのカード下にリンクが表示されること
- [ ] トライアルページのフッターにリンクが表示されること
- [ ] サイドバーのフッターにリンクが表示されること

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)