### PR TITLE
feat: 一般ユーザー向けAI出題案生成機能

### DIFF
--- a/apps/api/src/application/question-proposal/bulk-create-question-proposals.ts
+++ b/apps/api/src/application/question-proposal/bulk-create-question-proposals.ts
@@ -18,6 +18,7 @@ export class BulkCreateQuestionProposals {
   async execute(input: {
     categoryId: string;
     questions: GeneratedQuestion[];
+    userId?: string;
   }): Promise<QuestionProposal[]> {
     const categoryId = Id.of<Category>(input.categoryId);
 
@@ -32,6 +33,7 @@ export class BulkCreateQuestionProposals {
           correctIndexes: CorrectIndexes.create(q.correctIndexes),
           explanation: Explanation.create(q.explanation),
           categoryId,
+          userId: input.userId,
         });
 
         await this.questionProposalRepository.save(proposal, event);

--- a/apps/api/src/application/question-proposal/generate-candidates.ts
+++ b/apps/api/src/application/question-proposal/generate-candidates.ts
@@ -5,7 +5,7 @@ import type {
 } from "./question-generation-service.ts";
 
 const DEFAULT_QUESTION_COUNT = 10;
-const FREE_INPUT_QUESTION_COUNT = 3;
+const FREE_INPUT_QUESTION_COUNT = 5;
 
 export class GenerateCandidates {
   constructor(private questionGenerationService: QuestionGenerationService) {}

--- a/apps/api/src/presentation/routes/user-proposals/user-proposals.route.ts
+++ b/apps/api/src/presentation/routes/user-proposals/user-proposals.route.ts
@@ -54,6 +54,8 @@ const proposalIdParam = z.object({
   id: z.string().uuid(),
 });
 
+const USER_MAX_CANDIDATES = 5;
+
 const userGenerateCandidatesSchema = z
   .discriminatedUnion("type", [
     z.object({
@@ -80,7 +82,7 @@ const generatedQuestionSchema = z
 const userBulkCreateSchema = z
   .object({
     categoryId: z.string().uuid(),
-    questions: z.array(generatedQuestionSchema).min(1).max(5),
+    questions: z.array(generatedQuestionSchema).min(1).max(USER_MAX_CANDIDATES),
   })
   .openapi("UserBulkCreateRequest");
 
@@ -283,9 +285,10 @@ export const createUserProposalsRoute = (deps: Dependencies) =>
       return c.json(toQuestionProposalResponse(proposal));
     })
     .openapi(generateCandidatesRoute, async (c) => {
+      c.get("user"); // 認証確認（将来のレート制限・ログ用）
       const source = c.req.valid("json");
       const candidates = await deps.generateCandidates.execute(source);
-      return c.json({ candidates: candidates.slice(0, 5) });
+      return c.json({ candidates: candidates.slice(0, USER_MAX_CANDIDATES) });
     })
     .openapi(bulkCreateRoute, async (c) => {
       const user = c.get("user");

--- a/apps/api/src/presentation/routes/user-proposals/user-proposals.route.ts
+++ b/apps/api/src/presentation/routes/user-proposals/user-proposals.route.ts
@@ -54,6 +54,36 @@ const proposalIdParam = z.object({
   id: z.string().uuid(),
 });
 
+const userGenerateCandidatesSchema = z
+  .discriminatedUnion("type", [
+    z.object({
+      type: z.literal("url"),
+      url: z.string().url(),
+    }),
+    z.object({
+      type: z.literal("freeInput"),
+      input: z.string().min(1).max(2000),
+    }),
+  ])
+  .openapi("UserGenerateCandidatesRequest");
+
+const generatedQuestionSchema = z
+  .object({
+    questionText: z.string(),
+    difficulty: z.enum(["easy", "medium", "hard"]),
+    choices: z.array(z.string()).min(2).max(10),
+    correctIndexes: z.array(z.number().int().min(0)).min(1).max(10),
+    explanation: z.string(),
+  })
+  .openapi("UserGeneratedQuestion");
+
+const userBulkCreateSchema = z
+  .object({
+    categoryId: z.string().uuid(),
+    questions: z.array(generatedQuestionSchema).min(1).max(5),
+  })
+  .openapi("UserBulkCreateRequest");
+
 const proposalResponse = {
   200: {
     description: "出題案",
@@ -150,6 +180,54 @@ const submitRoute = createRoute({
   responses: proposalResponse,
 });
 
+const generateCandidatesRoute = createRoute({
+  method: "post",
+  path: "/generate-candidates",
+  tags: ["UserProposal"],
+  summary: "URL・キーワードからAI出題候補を生成（DB保存なし）",
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: userGenerateCandidatesSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "生成された候補一覧",
+      content: {
+        "application/json": {
+          schema: z.object({
+            candidates: z.array(generatedQuestionSchema),
+          }),
+        },
+      },
+    },
+  },
+});
+
+const bulkCreateRoute = createRoute({
+  method: "post",
+  path: "/bulk-create",
+  tags: ["UserProposal"],
+  summary: "選択した出題候補を一括登録",
+  request: {
+    body: {
+      content: { "application/json": { schema: userBulkCreateSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "作成された出題案一覧",
+      content: {
+        "application/json": {
+          schema: z.array(questionProposalSchema),
+        },
+      },
+    },
+  },
+});
+
 export const createUserProposalsRoute = (deps: Dependencies) =>
   new OpenAPIHono<AuthEnv>()
     .openapi(listRoute, async (c) => {
@@ -203,4 +281,18 @@ export const createUserProposalsRoute = (deps: Dependencies) =>
         callerId: user.id,
       });
       return c.json(toQuestionProposalResponse(proposal));
+    })
+    .openapi(generateCandidatesRoute, async (c) => {
+      const source = c.req.valid("json");
+      const candidates = await deps.generateCandidates.execute(source);
+      return c.json({ candidates: candidates.slice(0, 5) });
+    })
+    .openapi(bulkCreateRoute, async (c) => {
+      const user = c.get("user");
+      const input = c.req.valid("json");
+      const proposals = await deps.bulkCreateQuestionProposals.execute({
+        ...input,
+        userId: user.id,
+      });
+      return c.json(proposals.map(toQuestionProposalResponse));
     });

--- a/apps/web/src/features/proposals/proposal-generate-page.tsx
+++ b/apps/web/src/features/proposals/proposal-generate-page.tsx
@@ -1,0 +1,440 @@
+import { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ArrowLeft, Sparkles, CheckSquare, Square, Eye } from "lucide-react";
+import { ProposalContentCards } from "../admin/proposals/proposal-content-cards";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { InferRequestType, InferResponseType } from "hono/client";
+import { client } from "@/client";
+import { difficultyLabels } from "../admin/proposals/constants";
+
+type GenerateCandidatesEndpoint =
+  (typeof client.api)["user-proposals"]["generate-candidates"]["$post"];
+type GenerateCandidatesResponse = InferResponseType<GenerateCandidatesEndpoint>;
+type GenerateCandidatesBody =
+  InferRequestType<GenerateCandidatesEndpoint>["json"];
+type Candidate = GenerateCandidatesResponse["candidates"][number];
+
+const urlSchema = z.object({
+  sourceType: z.literal("url"),
+  url: z.string().trim().url("有効な URL を入力してください"),
+  categoryId: z.string().uuid("カテゴリを選択してください"),
+});
+
+const freeInputSchema = z.object({
+  sourceType: z.literal("freeInput"),
+  input: z
+    .string()
+    .min(1, "キーワードまたは説明文を入力してください")
+    .max(2000, "2000文字以内で入力してください"),
+  categoryId: z.string().uuid("カテゴリを選択してください"),
+});
+
+const generateSchema = z.discriminatedUnion("sourceType", [
+  urlSchema,
+  freeInputSchema,
+]);
+
+type GenerateForm = z.infer<typeof generateSchema>;
+
+export function UserProposalGeneratePage() {
+  const navigate = useNavigate();
+
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [selectedIndexes, setSelectedIndexes] = useState<Set<number>>(
+    new Set(),
+  );
+  const [detailIndex, setDetailIndex] = useState<number | null>(null);
+
+  const form = useForm<GenerateForm>({
+    resolver: zodResolver(generateSchema),
+    defaultValues: {
+      sourceType: "url",
+      url: "",
+      categoryId: "",
+    } as GenerateForm,
+  });
+
+  const sourceType = form.watch("sourceType");
+
+  const { data: categories } = useQuery({
+    queryKey: ["categories"],
+    queryFn: async () => {
+      const res = await client.api.categories.$get();
+      if (!res.ok) throw new Error("Failed to fetch categories");
+      return res.json();
+    },
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: async (data: GenerateForm) => {
+      let json: GenerateCandidatesBody;
+
+      if (data.sourceType === "url") {
+        json = { type: "url", url: data.url };
+      } else {
+        json = { type: "freeInput", input: data.input };
+      }
+
+      const res = await client.api["user-proposals"][
+        "generate-candidates"
+      ].$post({ json });
+      if (!res.ok) {
+        if ((res as Response).status === 503) {
+          throw new Error(
+            "現在AI生成が利用できません。しばらく時間をおいてお試しください",
+          );
+        }
+        throw new Error("生成に失敗しました");
+      }
+      return res.json();
+    },
+    onSuccess: (data) => {
+      setCandidates(data.candidates);
+      setSelectedIndexes(new Set(data.candidates.map((_, i) => i)));
+    },
+  });
+
+  const bulkCreateMutation = useMutation({
+    mutationFn: async () => {
+      const selectedQuestions = candidates.filter((_, i) =>
+        selectedIndexes.has(i),
+      );
+      const res = await client.api["user-proposals"]["bulk-create"].$post({
+        json: {
+          categoryId: form.getValues("categoryId"),
+          questions: selectedQuestions,
+        },
+      });
+      if (!res.ok) throw new Error("登録に失敗しました");
+      return res.json();
+    },
+    onSuccess: () => {
+      setCandidates([]);
+      navigate("/proposals");
+    },
+  });
+
+  const toggleSelect = useCallback((index: number) => {
+    setSelectedIndexes((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    setSelectedIndexes((prev) =>
+      prev.size === candidates.length
+        ? new Set()
+        : new Set(candidates.map((_, i) => i)),
+    );
+  }, [candidates]);
+
+  const detailCandidate = detailIndex !== null ? candidates[detailIndex] : null;
+
+  return (
+    <div className="space-y-6 px-2">
+      <div className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate("/proposals")}
+        >
+          <ArrowLeft className="size-4" />
+          一覧へ戻る
+        </Button>
+      </div>
+
+      <h2 className="text-2xl font-bold tracking-tight">AI で問題を生成</h2>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">生成設定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit((data) =>
+                generateMutation.mutate(data),
+              )}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="sourceType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ソースの種類</FormLabel>
+                    <FormControl>
+                      <RadioGroup
+                        value={field.value}
+                        onValueChange={(value) => {
+                          field.onChange(value);
+                          form.setValue("url" as never, "" as never);
+                          form.setValue("input" as never, "" as never);
+                        }}
+                        className="flex gap-4"
+                      >
+                        {(
+                          [
+                            ["url", "URL"],
+                            ["freeInput", "キーワード・説明文"],
+                          ] as const
+                        ).map(([value, label]) => (
+                          <label
+                            key={value}
+                            className="flex items-center gap-2 cursor-pointer"
+                          >
+                            <RadioGroupItem value={value} />
+                            {label}
+                          </label>
+                        ))}
+                      </RadioGroup>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              {sourceType === "url" && (
+                <FormField
+                  control={form.control}
+                  name="url"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>参照 URL</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="url"
+                          placeholder="https://example.com/article"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              {sourceType === "freeInput" && (
+                <FormField
+                  control={form.control}
+                  name="input"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>キーワード・説明文</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="例: GHS、または説明文を入力"
+                          rows={4}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              <FormField
+                control={form.control}
+                name="categoryId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>カテゴリ</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-60">
+                          <SelectValue placeholder="選択してください" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {categories?.map((cat) => (
+                          <SelectItem key={cat.id} value={cat.id}>
+                            {cat.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" disabled={generateMutation.isPending}>
+                <Sparkles className="size-4" />
+                {generateMutation.isPending
+                  ? "生成中（時間がかかります）..."
+                  : "生成する"}
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {generateMutation.isError && (
+        <p className="text-sm text-destructive">
+          エラー: {generateMutation.error.message}
+        </p>
+      )}
+
+      {bulkCreateMutation.isError && (
+        <p className="text-sm text-destructive">
+          登録エラー: {bulkCreateMutation.error.message}
+        </p>
+      )}
+
+      {candidates.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              生成候補（{candidates.length} 件中 {selectedIndexes.size} 件選択）
+            </CardTitle>
+            <div className="flex items-center gap-2 pt-2">
+              <Button variant="outline" size="sm" onClick={toggleAll}>
+                {selectedIndexes.size === candidates.length ? (
+                  <Square className="size-4" />
+                ) : (
+                  <CheckSquare className="size-4" />
+                )}
+                {selectedIndexes.size === candidates.length
+                  ? "全解除"
+                  : "全選択"}
+              </Button>
+              <Button
+                size="sm"
+                disabled={
+                  selectedIndexes.size === 0 || bulkCreateMutation.isPending
+                }
+                onClick={() => bulkCreateMutation.mutate()}
+              >
+                {bulkCreateMutation.isPending
+                  ? "登録中..."
+                  : `選択した ${selectedIndexes.size} 件を登録`}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader className="bg-primary/10">
+                  <TableRow className="border-b-2 border-primary/30">
+                    <TableHead className="w-10" />
+                    <TableHead className="w-[55%] font-bold text-primary">
+                      問題文
+                    </TableHead>
+                    <TableHead className="font-bold text-primary">
+                      難易度
+                    </TableHead>
+                    <TableHead className="font-bold text-primary">
+                      操作
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {candidates.map((candidate, index) => (
+                    <TableRow key={index}>
+                      <TableCell>
+                        <Checkbox
+                          checked={selectedIndexes.has(index)}
+                          onCheckedChange={() => toggleSelect(index)}
+                        />
+                      </TableCell>
+                      <TableCell className="max-w-0 truncate">
+                        {candidate.questionText}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">
+                          {difficultyLabels[candidate.difficulty] ??
+                            candidate.difficulty}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDetailIndex(index)}
+                        >
+                          <Eye className="size-4" />
+                          詳細
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog
+        open={detailIndex !== null}
+        onOpenChange={(open) => {
+          if (!open) setDetailIndex(null);
+        }}
+      >
+        <DialogContent className="flex max-h-[80vh] max-w-2xl flex-col overflow-hidden sm:max-w-2xl">
+          <DialogHeader className="shrink-0 border-b pb-4">
+            <DialogTitle>問題詳細</DialogTitle>
+          </DialogHeader>
+          {detailCandidate && (
+            <div className="space-y-4 overflow-y-auto pr-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary">
+                  {difficultyLabels[detailCandidate.difficulty] ??
+                    detailCandidate.difficulty}
+                </Badge>
+              </div>
+              <ProposalContentCards
+                text={detailCandidate.questionText}
+                choices={detailCandidate.choices}
+                correctIndexes={detailCandidate.correctIndexes}
+                explanation={detailCandidate.explanation}
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/features/proposals/proposal-list-page.tsx
+++ b/apps/web/src/features/proposals/proposal-list-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { HandHeart, Plus } from "lucide-react";
+import { HandHeart, Plus, Sparkles } from "lucide-react";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -60,10 +60,19 @@ export function UserProposalListPage() {
     <div className="space-y-6 px-2">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold tracking-tight">出題案</h2>
-        <Button onClick={() => navigate("/proposals/new")}>
-          <Plus className="size-4" />
-          新規作成
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => navigate("/proposals/generate")}
+          >
+            <Sparkles className="size-4" />
+            AI生成
+          </Button>
+          <Button onClick={() => navigate("/proposals/new")}>
+            <Plus className="size-4" />
+            新規作成
+          </Button>
+        </div>
       </div>
 
       <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-gradient-to-br from-blue-50 to-green-50 px-5 py-4">

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,6 +26,7 @@ import { AccountPage } from "./features/account/account-page";
 import { UserProposalListPage } from "./features/proposals/proposal-list-page";
 import { UserProposalNewPage } from "./features/proposals/proposal-new-page";
 import { UserProposalDetailPage } from "./features/proposals/proposal-detail-page";
+import { UserProposalGeneratePage } from "./features/proposals/proposal-generate-page";
 import { PrivacyPage } from "./features/legal/privacy-page";
 import { TermsPage } from "./features/legal/terms-page";
 import "./index.css";
@@ -49,6 +50,10 @@ function Root() {
               <Route path="/drill" element={<DrillPage />} />
               <Route path="/proposals" element={<UserProposalListPage />} />
               <Route path="/proposals/new" element={<UserProposalNewPage />} />
+              <Route
+                path="/proposals/generate"
+                element={<UserProposalGeneratePage />}
+              />
               <Route
                 path="/proposals/:id"
                 element={<UserProposalDetailPage />}


### PR DESCRIPTION
## Summary
- 一般ユーザーがURL/フリー入力からAIで出題案候補を5問生成し、選択して保存できるようにした
- `user-proposals` ルートに `generate-candidates` / `bulk-create` エンドポイントを追加
- フリー入力時の生成数を3問→5問に変更（管理者側も同様）

## 変更内容
- **API**: `user-proposals` に2エンドポイント追加、`BulkCreateQuestionProposals` に `userId` オプション追加
- **Web**: ユーザー向けAI生成ページ新設、出題案一覧にAI生成ボタン追加
- 既存の管理者向けインフラ（Geminiアダプター、ドメインモデル）はそのまま再利用

## Test plan
- [ ] `pnpm type-check` パス確認済
- [ ] `pnpm test` 全120テストパス確認済
- [ ] `pnpm lint` エラーなし確認済
- [ ] 一般ユーザーでログインし `/proposals/generate` でAI生成が動作すること
- [ ] 生成した候補を選択して保存→出題案一覧に表示されること
- [ ] 保存された出題案に `userId` が紐付いていること

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)