### PR TITLE
feat: 出題案作成画面に注意文言を追加

### DIFF
--- a/apps/web/src/features/proposals/proposal-caution-banner.tsx
+++ b/apps/web/src/features/proposals/proposal-caution-banner.tsx
@@ -1,0 +1,24 @@
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function ProposalCautionBanner({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-5 py-4",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className="size-7 shrink-0 text-amber-600"
+        strokeWidth={1.5}
+      />
+      <div>
+        <p className="text-sm font-semibold text-amber-800">ご注意ください</p>
+        <p className="mt-0.5 text-xs text-slate-600">
+          個人情報や特定の法人に関わる出題案は作成しないでください。万が一作成・申請された場合でも、問題として公開されることはありません。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/proposals/proposal-generate-page.tsx
+++ b/apps/web/src/features/proposals/proposal-generate-page.tsx
@@ -4,15 +4,9 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import {
-  AlertTriangle,
-  ArrowLeft,
-  Sparkles,
-  CheckSquare,
-  Square,
-  Eye,
-} from "lucide-react";
+import { ArrowLeft, Sparkles, CheckSquare, Square, Eye } from "lucide-react";
 import { ProposalContentCards } from "../admin/proposals/proposal-content-cards";
+import { ProposalCautionBanner } from "./proposal-caution-banner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -194,18 +188,7 @@ export function UserProposalGeneratePage() {
 
       <h2 className="text-2xl font-bold tracking-tight">AI で問題を生成</h2>
 
-      <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-5 py-4">
-        <AlertTriangle
-          className="size-7 shrink-0 text-amber-600"
-          strokeWidth={1.5}
-        />
-        <div>
-          <p className="text-sm font-semibold text-amber-800">ご注意ください</p>
-          <p className="mt-0.5 text-xs text-slate-600">
-            個人情報や特定の法人に関わる出題案は作成しないでください。万が一作成・申請された場合でも、問題として公開されることはありません。
-          </p>
-        </div>
-      </div>
+      <ProposalCautionBanner />
 
       <Card>
         <CardHeader>

--- a/apps/web/src/features/proposals/proposal-generate-page.tsx
+++ b/apps/web/src/features/proposals/proposal-generate-page.tsx
@@ -4,7 +4,14 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, Sparkles, CheckSquare, Square, Eye } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Sparkles,
+  CheckSquare,
+  Square,
+  Eye,
+} from "lucide-react";
 import { ProposalContentCards } from "../admin/proposals/proposal-content-cards";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -186,6 +193,19 @@ export function UserProposalGeneratePage() {
       </div>
 
       <h2 className="text-2xl font-bold tracking-tight">AI で問題を生成</h2>
+
+      <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-5 py-4">
+        <AlertTriangle
+          className="size-7 shrink-0 text-amber-600"
+          strokeWidth={1.5}
+        />
+        <div>
+          <p className="text-sm font-semibold text-amber-800">ご注意ください</p>
+          <p className="mt-0.5 text-xs text-slate-600">
+            個人情報や特定の法人に関わる出題案は作成しないでください。万が一作成・申請された場合でも、問題として公開されることはありません。
+          </p>
+        </div>
+      </div>
 
       <Card>
         <CardHeader>

--- a/apps/web/src/features/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/proposals/proposal-new-page.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
 import {
   ProposalEditForm,
   type EditFormData,
@@ -30,23 +31,37 @@ export function UserProposalNewPage() {
   });
 
   return (
-    <ProposalEditForm
-      defaultValues={{
-        questionText: "",
-        difficulty: "medium",
-        choices: [{ value: "" }, { value: "" }, { value: "" }, { value: "" }],
-        correctIndexes: [],
-        explanation: "",
-        categoryId: "",
-      }}
-      onSubmit={(data) => createMutation.mutate(data)}
-      onCancel={() => navigate("/proposals")}
-      isPending={createMutation.isPending}
-      error={createMutation.error?.message}
-      title="出題案を作成"
-      cancelLabel="一覧へ戻る"
-      submitLabel="出題案を作成"
-      showFooterCancel={false}
-    />
+    <div className="space-y-6">
+      <div className="mx-2 flex items-center gap-3 rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-5 py-4">
+        <AlertTriangle
+          className="size-7 shrink-0 text-amber-600"
+          strokeWidth={1.5}
+        />
+        <div>
+          <p className="text-sm font-semibold text-amber-800">ご注意ください</p>
+          <p className="mt-0.5 text-xs text-slate-600">
+            個人情報や特定の法人に関わる出題案は作成しないでください。万が一作成・申請された場合でも、問題として公開されることはありません。
+          </p>
+        </div>
+      </div>
+      <ProposalEditForm
+        defaultValues={{
+          questionText: "",
+          difficulty: "medium",
+          choices: [{ value: "" }, { value: "" }, { value: "" }, { value: "" }],
+          correctIndexes: [],
+          explanation: "",
+          categoryId: "",
+        }}
+        onSubmit={(data) => createMutation.mutate(data)}
+        onCancel={() => navigate("/proposals")}
+        isPending={createMutation.isPending}
+        error={createMutation.error?.message}
+        title="出題案を作成"
+        cancelLabel="一覧へ戻る"
+        submitLabel="出題案を作成"
+        showFooterCancel={false}
+      />
+    </div>
   );
 }

--- a/apps/web/src/features/proposals/proposal-new-page.tsx
+++ b/apps/web/src/features/proposals/proposal-new-page.tsx
@@ -1,10 +1,10 @@
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
-import { AlertTriangle } from "lucide-react";
 import {
   ProposalEditForm,
   type EditFormData,
 } from "../admin/proposals/proposal-edit-form";
+import { ProposalCautionBanner } from "./proposal-caution-banner";
 import { client } from "@/client";
 
 export function UserProposalNewPage() {
@@ -32,18 +32,7 @@ export function UserProposalNewPage() {
 
   return (
     <div className="space-y-6">
-      <div className="mx-2 flex items-center gap-3 rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-yellow-50 px-5 py-4">
-        <AlertTriangle
-          className="size-7 shrink-0 text-amber-600"
-          strokeWidth={1.5}
-        />
-        <div>
-          <p className="text-sm font-semibold text-amber-800">ご注意ください</p>
-          <p className="mt-0.5 text-xs text-slate-600">
-            個人情報や特定の法人に関わる出題案は作成しないでください。万が一作成・申請された場合でも、問題として公開されることはありません。
-          </p>
-        </div>
-      </div>
+      <ProposalCautionBanner className="mx-2" />
       <ProposalEditForm
         defaultValues={{
           questionText: "",


### PR DESCRIPTION
## Summary
- 出題案の手動作成ページ（`/proposals/new`）と AI 生成ページ（`/proposals/generate`）に、個人情報や特定法人に関わる出題案を作成しないよう注意を促すバナーを追加
- 一覧ページの既存バナーと統一感のある amber 系グラデーションデザインを採用

Closes #115

## Test plan
- [ ] `/proposals/new` にアクセスし、フォーム上部に amber 系の注意バナーが表示されることを確認
- [ ] `/proposals/generate` にアクセスし、タイトルと生成設定カードの間に注意バナーが表示されることを確認
- [ ] 各画面でフォームのレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)