### PR TITLE
fix: カテゴリ選択画面のカードをコンパクト化

### DIFF
--- a/apps/web/src/features/drill/category-select-page.tsx
+++ b/apps/web/src/features/drill/category-select-page.tsx
@@ -76,7 +76,7 @@ export function CategorySelectPage() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-6 px-4 py-8">
+    <div className="mx-auto w-full max-w-2xl space-y-4 px-4 py-8">
       <div className="space-y-1">
         <h2 className="text-lg font-semibold">カテゴリを選択</h2>
         <p className="text-sm text-muted-foreground">
@@ -84,24 +84,24 @@ export function CategorySelectPage() {
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-1.5 sm:grid-cols-2 md:grid-cols-3">
         <Card
-          className={`cursor-pointer transition-colors ${
+          className={`cursor-pointer py-2 gap-1 transition-colors ${
             selectedCategoryId === null
               ? "border-primary ring-1 ring-primary"
               : "hover:border-primary/50"
           }`}
           onClick={() => setSelectedCategoryId(null)}
         >
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">すべて</CardTitle>
+          <CardHeader className="p-3 pb-1">
+            <CardTitle className="text-sm">すべて</CardTitle>
           </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
+          <CardContent className="p-3 pt-0">
+            <p className="text-xs text-muted-foreground">
               {totalQuestionCount} 問
             </p>
             {overallCorrectRate !== null ? (
-              <div className="mt-2 flex gap-2">
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
                 <Badge variant="outline" className="text-xs">
                   正答率 {Math.round(overallCorrectRate * 100)}%
                 </Badge>
@@ -110,7 +110,7 @@ export function CategorySelectPage() {
                 </Badge>
               </div>
             ) : (
-              <Badge variant="secondary" className="mt-2 text-xs">
+              <Badge variant="secondary" className="mt-1.5 text-xs">
                 未挑戦
               </Badge>
             )}
@@ -122,22 +122,22 @@ export function CategorySelectPage() {
           return (
             <Card
               key={category.id}
-              className={`cursor-pointer transition-colors ${
+              className={`cursor-pointer py-2 gap-1 transition-colors ${
                 selectedCategoryId === category.id
                   ? "border-primary ring-1 ring-primary"
                   : "hover:border-primary/50"
               }`}
               onClick={() => setSelectedCategoryId(category.id)}
             >
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{category.name}</CardTitle>
+              <CardHeader className="p-3 pb-1">
+                <CardTitle className="text-sm">{category.name}</CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
+              <CardContent className="p-3 pt-0">
+                <p className="text-xs text-muted-foreground">
                   {category.questionCount} 問
                 </p>
                 {score ? (
-                  <div className="mt-2 flex gap-2">
+                  <div className="mt-1.5 flex flex-wrap gap-1.5">
                     <Badge variant="outline" className="text-xs">
                       正答率 {Math.round(score.correctRate * 100)}%
                     </Badge>
@@ -146,7 +146,7 @@ export function CategorySelectPage() {
                     </Badge>
                   </div>
                 ) : (
-                  <Badge variant="secondary" className="mt-2 text-xs">
+                  <Badge variant="secondary" className="mt-1.5 text-xs">
                     未挑戦
                   </Badge>
                 )}


### PR DESCRIPTION
## Summary
- カテゴリ選択画面（トップ画面）でカテゴリカードが大きすぎて「開始」ボタンがファーストビューに表示されず、お試しユーザーが操作に迷う問題を修正
- カードのグリッドを2列→3列（md以上）に変更し、余白を縮小してコンパクト化
- 成績バッジは維持しつつ、flex-wrapで折り返し対応

## 変更内容
- グリッド: `sm:grid-cols-2` → `sm:grid-cols-2 md:grid-cols-3`、gap縮小
- Cardの余白: `py-6 gap-6` → `py-2 gap-1`
- CardHeader/CardContent: padding縮小
- セクション間余白: `space-y-6` → `space-y-4`
- 成績バッジコンテナ: `flex-wrap`追加

## Test plan
- [ ] デスクトップ(md以上)でカテゴリカードが3列表示されること
- [ ] タブレット(sm)でカテゴリカードが2列表示されること
- [ ] モバイルでカテゴリカードが1列表示されること
- [ ] 「開始」ボタンがスクロールなしで見えること
- [ ] 成績バッジが正しく表示・折り返しされること
- [ ] カテゴリ選択 → 出題数選択 → 開始 の操作フローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)