### PR TITLE
fix: ドリル結果画面のEXP獲得・レベルアップ表示のラグを改善

### DIFF
--- a/apps/api/src/application/drill-session/save-drill-session.ts
+++ b/apps/api/src/application/drill-session/save-drill-session.ts
@@ -6,7 +6,10 @@ import {
 } from "../../domain/drill-session/entity/drill-session.ts";
 import type { DrillSessionRepository } from "../../domain/drill-session/repository/drill-session-repository.ts";
 import type { UnitOfWork } from "../unit-of-work.ts";
-import type { AddExperience } from "../user-experience/add-experience.ts";
+import type {
+  AddExperience,
+  RankUpEventDto,
+} from "../user-experience/add-experience.ts";
 
 export class SaveDrillSession {
   constructor(
@@ -20,7 +23,11 @@ export class SaveDrillSession {
     categoryId: string | null;
     answers: DrillAnswer[];
     startedAt: string;
-  }): Promise<{ sessionId: string; earnedExp: number }> {
+  }): Promise<{
+    sessionId: string;
+    earnedExp: number;
+    rankUps: RankUpEventDto[];
+  }> {
     return this.uow.run(async () => {
       const sessionId = Id.random<DrillSession>() as DrillSessionId;
       const session = DrillSession.create({
@@ -34,14 +41,14 @@ export class SaveDrillSession {
       await this.drillSessionRepository.save(session);
 
       const expAmount = 10 + session.correctCount * 2;
-      await this.addExperience.run({
+      const rankUps = await this.addExperience.run({
         userId: params.userId,
         action: "drill_complete",
         referenceId: session.id,
         amount: expAmount,
       });
 
-      return { sessionId: session.id, earnedExp: expAmount };
+      return { sessionId: session.id, earnedExp: expAmount, rankUps };
     });
   }
 }

--- a/apps/api/src/application/user-experience/add-experience.ts
+++ b/apps/api/src/application/user-experience/add-experience.ts
@@ -4,12 +4,23 @@ import type {
   UserExperienceRepository,
   ExperienceAction,
 } from "../../domain/user-experience/repository/user-experience-repository.ts";
+import { getRankInfo } from "../../domain/user-experience/rank-definitions.ts";
 
 export type AddExperienceInput = {
   userId: string;
   action: ExperienceAction;
   referenceId: string;
   amount: number;
+};
+
+export type RankUpEventDto = {
+  id: string;
+  userId: string;
+  previousRank: number;
+  newRank: number;
+  substance: string;
+  category: string;
+  createdAt: string;
 };
 
 export class AddExperience {
@@ -19,14 +30,14 @@ export class AddExperience {
   ) {}
 
   /** トランザクション外から呼ぶ場合 */
-  async execute(input: AddExperienceInput): Promise<void> {
-    await this.uow.run(async () => {
-      await this.run(input);
+  async execute(input: AddExperienceInput): Promise<RankUpEventDto[]> {
+    return this.uow.run(async () => {
+      return this.run(input);
     });
   }
 
   /** 既存トランザクション内から呼ぶ場合 */
-  async run(input: AddExperienceInput): Promise<void> {
+  async run(input: AddExperienceInput): Promise<RankUpEventDto[]> {
     // 二重付与チェック（ログ挿入がfalseなら既に付与済み）
     const logged = await this.userExperienceRepository.saveExperienceLog({
       userId: input.userId,
@@ -34,7 +45,7 @@ export class AddExperience {
       amount: input.amount,
       referenceId: input.referenceId,
     });
-    if (!logged) return;
+    if (!logged) return [];
 
     // 現在の経験値を取得（なければ初期状態を作成）
     const current =
@@ -49,13 +60,27 @@ export class AddExperience {
 
     // ランクアップイベント保存
     if (rankUps.length > 0) {
-      await this.userExperienceRepository.saveRankUpEvents(
+      const saved = await this.userExperienceRepository.saveRankUpEvents(
         rankUps.map((r) => ({
           userId: input.userId,
           previousRank: r.previousRank,
           newRank: r.newRank,
         })),
       );
+      return saved.map((e) => {
+        const def = getRankInfo(e.newRank);
+        return {
+          id: e.id,
+          userId: e.userId,
+          previousRank: e.previousRank,
+          newRank: e.newRank,
+          substance: def.substance,
+          category: def.category,
+          createdAt: e.createdAt.toISOString(),
+        };
+      });
     }
+
+    return [];
   }
 }

--- a/apps/api/src/domain/user-experience/repository/user-experience-repository.ts
+++ b/apps/api/src/domain/user-experience/repository/user-experience-repository.ts
@@ -18,9 +18,17 @@ export type RankUpEventEntry = {
   newRank: number;
 };
 
+export type SavedRankUpEvent = {
+  id: string;
+  userId: string;
+  previousRank: number;
+  newRank: number;
+  createdAt: Date;
+};
+
 export interface UserExperienceRepository {
   save(userExperience: UserExperience): Promise<void>;
   findByUserId(userId: string): Promise<UserExperience | null>;
   saveExperienceLog(entry: ExperienceLogEntry): Promise<boolean>;
-  saveRankUpEvents(events: RankUpEventEntry[]): Promise<void>;
+  saveRankUpEvents(events: RankUpEventEntry[]): Promise<SavedRankUpEvent[]>;
 }

--- a/apps/api/src/infrastructure/user-experience/drizzle-user-experience-repository.ts
+++ b/apps/api/src/infrastructure/user-experience/drizzle-user-experience-repository.ts
@@ -10,6 +10,7 @@ import type {
   UserExperienceRepository,
   ExperienceLogEntry,
   RankUpEventEntry,
+  SavedRankUpEvent,
 } from "../../domain/user-experience/repository/user-experience-repository.ts";
 
 export class DrizzleUserExperienceRepository implements UserExperienceRepository {
@@ -69,15 +70,27 @@ export class DrizzleUserExperienceRepository implements UserExperienceRepository
     return (result as { rowCount?: number }).rowCount !== 0;
   }
 
-  async saveRankUpEvents(events: RankUpEventEntry[]): Promise<void> {
-    if (events.length === 0) return;
+  async saveRankUpEvents(
+    events: RankUpEventEntry[],
+  ): Promise<SavedRankUpEvent[]> {
+    if (events.length === 0) return [];
     const tx = getCurrentTransaction();
-    await tx.insert(rankUpEvents).values(
-      events.map((e) => ({
-        userId: e.userId,
-        previousRank: e.previousRank,
-        newRank: e.newRank,
-      })),
-    );
+    const rows = await tx
+      .insert(rankUpEvents)
+      .values(
+        events.map((e) => ({
+          userId: e.userId,
+          previousRank: e.previousRank,
+          newRank: e.newRank,
+        })),
+      )
+      .returning({
+        id: rankUpEvents.id,
+        userId: rankUpEvents.userId,
+        previousRank: rankUpEvents.previousRank,
+        newRank: rankUpEvents.newRank,
+        createdAt: rankUpEvents.createdAt,
+      });
+    return rows;
   }
 }

--- a/apps/api/src/presentation/routes/drill-sessions/drill-sessions.route.ts
+++ b/apps/api/src/presentation/routes/drill-sessions/drill-sessions.route.ts
@@ -9,6 +9,16 @@ const answerSchema = z.object({
   isCorrect: z.boolean(),
 });
 
+const rankUpEventSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string(),
+  previousRank: z.number().int(),
+  newRank: z.number().int(),
+  substance: z.string(),
+  category: z.string(),
+  createdAt: z.string().datetime(),
+});
+
 const saveDrillSessionRoute = createRoute({
   method: "post",
   path: "/",
@@ -38,6 +48,7 @@ const saveDrillSessionRoute = createRoute({
             .object({
               sessionId: z.string().uuid(),
               earnedExp: z.number().int(),
+              rankUps: z.array(rankUpEventSchema),
             })
             .openapi("SaveDrillSessionResponse"),
         },

--- a/apps/web/src/features/question/rank-up-modal.tsx
+++ b/apps/web/src/features/question/rank-up-modal.tsx
@@ -76,8 +76,8 @@ export function RankUpModal({ rankUps, onClose }: Props) {
         className="rank-up-glow text-center sm:max-w-md"
         style={{ "--glow-color": style.glow } as React.CSSProperties}
       >
-        <DialogHeader>
-          <DialogTitle className="rank-up-title text-2xl font-bold">
+        <DialogHeader className="text-center">
+          <DialogTitle className="rank-up-title text-center text-2xl font-bold">
             取扱許可レベルアップ！
           </DialogTitle>
         </DialogHeader>

--- a/apps/web/src/features/question/result-screen.tsx
+++ b/apps/web/src/features/question/result-screen.tsx
@@ -1,50 +1,37 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import type { AnswerResult } from "@/types/question";
 import { Trophy, Zap } from "lucide-react";
-import { client } from "@/client";
 import { RankUpModal } from "./rank-up-modal";
+
+type RankUpEvent = {
+  id: string;
+  userId: string;
+  previousRank: number;
+  newRank: number;
+  substance: string;
+  category: string;
+  createdAt: string;
+};
 
 type Props = {
   results: AnswerResult[];
   onRetry?: () => void;
   children?: React.ReactNode;
   earnedExp?: number | null;
-  checkRankUp?: boolean;
+  rankUps?: RankUpEvent[];
 };
-
-/** セッション保存完了後にランクアップをチェックし、モーダルを表示する */
-function RankUpChecker() {
-  const [showModal, setShowModal] = useState(true);
-
-  const { data: pendingRankUps } = useQuery({
-    queryKey: ["rank", "pending-rank-ups"],
-    queryFn: async () => {
-      const res = await client.api.rank["pending-rank-ups"].$get();
-      if (!res.ok) throw new Error("Failed to fetch pending rank ups");
-      return res.json();
-    },
-  });
-
-  if (!showModal || !pendingRankUps || pendingRankUps.length === 0) {
-    return null;
-  }
-
-  return (
-    <RankUpModal rankUps={pendingRankUps} onClose={() => setShowModal(false)} />
-  );
-}
 
 export function ResultScreen({
   results,
   onRetry,
   children,
   earnedExp,
-  checkRankUp = false,
+  rankUps = [],
 }: Props) {
+  const [showRankUpModal, setShowRankUpModal] = useState(true);
   const total = results.length;
   const correct = results.filter((r) => r.isCorrect).length;
   const percentage = total > 0 ? Math.round((correct / total) * 100) : 0;
@@ -90,7 +77,12 @@ export function ResultScreen({
         </CardContent>
       </Card>
 
-      {checkRankUp && <RankUpChecker />}
+      {showRankUpModal && rankUps.length > 0 && (
+        <RankUpModal
+          rankUps={rankUps}
+          onClose={() => setShowRankUpModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/features/question/session-container.tsx
+++ b/apps/web/src/features/question/session-container.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { CircleStop } from "lucide-react";
 import type { QuestionDto } from "@/types/question";
@@ -18,6 +18,16 @@ import { useSessionReducer } from "./use-session-reducer";
 import { QuestionCard } from "./question-card";
 import { SessionProgress } from "./session-progress";
 import { ResultScreen } from "./result-screen";
+
+type RankUpEvent = {
+  id: string;
+  userId: string;
+  previousRank: number;
+  newRank: number;
+  substance: string;
+  category: string;
+  createdAt: string;
+};
 
 type Props = {
   questions: QuestionDto[];
@@ -42,8 +52,7 @@ export function SessionContainer({
   const startedAtRef = useRef(new Date().toISOString());
   const hasSavedRef = useRef(false);
 
-  const [sessionSaved, setSessionSaved] = useState(false);
-  const [earnedExp, setEarnedExp] = useState<number | null>(null);
+  const [rankUps, setRankUps] = useState<RankUpEvent[]>([]);
 
   const saveMutation = useMutation({
     mutationFn: async () => {
@@ -62,8 +71,9 @@ export function SessionContainer({
       return res.json();
     },
     onSuccess: (data) => {
-      setSessionSaved(true);
-      setEarnedExp(data.earnedExp);
+      if (data.rankUps.length > 0) {
+        setRankUps(data.rankUps);
+      }
     },
   });
 
@@ -74,13 +84,19 @@ export function SessionContainer({
     }
   }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const earnedExp = useMemo(() => {
+    if (state.phase !== "completed" || !saveResult) return null;
+    const correctCount = state.results.filter((r) => r.isCorrect).length;
+    return 10 + correctCount * 2;
+  }, [state.phase, state.results, saveResult]);
+
   if (state.phase === "completed") {
     return (
       <ResultScreen
         results={state.results}
         onRetry={showRetry ? reset : undefined}
         earnedExp={earnedExp}
-        checkRankUp={saveResult && sessionSaved}
+        rankUps={rankUps}
       >
         {resultActions}
       </ResultScreen>


### PR DESCRIPTION
## Summary

- EXP獲得表示をクライアント側で即時計算（`10 + correctCount * 2`）するように変更し、APIレスポンス待ちを解消
- `POST /api/drill-sessions` のレスポンスにランクアップ情報を含めるようにし、`GET /api/rank/pending-rank-ups` への2回目のAPIコールを不要に
- レベルアップモーダルのタイトルを中央寄せに修正

## 変更内容

### バックエンド
- `saveRankUpEvents` が保存済みレコード（id, createdAt含む）を返すように変更（`.returning()` 使用）
- `AddExperience.run()` が `RankUpEventDto[]` を返すように変更（`getRankInfo()` で substance/category を付与）
- `SaveDrillSession.execute()` のレスポンスに `rankUps` を追加
- APIルートの Zod スキーマに `rankUps` 配列を追加

### フロントエンド
- `session-container.tsx`: EXP を `useMemo` で即時計算、`rankUps` を POST レスポンスから取得
- `result-screen.tsx`: `RankUpChecker`（GET で取りに行くコンポーネント）を削除し、`rankUps` を props 経由に変更
- `rank-up-modal.tsx`: タイトルの中央寄せ

## Test plan

- [x] `pnpm type-check` 全パッケージでエラーなし
- [x] `pnpm lint` エラーなし
- [x] `pnpm test` 120テスト全パス
- [ ] ドリルを最後まで解答し、結果画面遷移と同時に「+xxEXP 獲得！」が即座に表示されることを確認
- [ ] ランクアップ発生時、POST レスポンス後すぐにモーダルが表示されることを確認
- [ ] ランクアップモーダルを閉じた後、成績画面で正しいランクが反映されていることを確認

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)