### PR TITLE
feat: DDoSコスト対策（Geo制限・Lambda同時実行数制限）

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -72,6 +72,21 @@ export default $config({
         basicAuthUser.value,
         basicAuthPassword.value,
       ),
+      // Geo 制限: 日本からのアクセスのみ許可（DDoS コスト対策）
+      transform: {
+        cdn: {
+          transform: {
+            distribution: {
+              restrictions: {
+                geoRestriction: {
+                  restrictionType: "whitelist",
+                  locations: ["JP"],
+                },
+              },
+            },
+          },
+        },
+      },
     });
 
     // キャッチオールルート: 全リクエストを Hono に委譲
@@ -79,6 +94,10 @@ export default $config({
       handler: "apps/api/src/lambda.handler",
       memory: "512 MB",
       timeout: "30 seconds",
+      // Lambda 同時実行数の上限（DDoS コスト対策）
+      concurrency: {
+        reserved: 10,
+      },
       environment: {
         DATABASE_URL: databaseUrl.value,
         GEMINI_API_KEY: geminiApiKey.value,


### PR DESCRIPTION
## Summary
- CloudFrontにGeo制限（日本のみ）を追加し、海外からのDDoS攻撃によるデータ転送コストを防止
- Lambda同時実行数を10に制限し、大量リクエスト時のスケール爆発を抑制
- 参考: https://qiita.com/kawabe0201/items/546235a8b9a0e90ef095

## Test plan
- [x] dev環境へのデプロイ成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)